### PR TITLE
[DNM] adding codemirror theme config

### DIFF
--- a/jupyter_book/book_template/_config.yml
+++ b/jupyter_book/book_template/_config.yml
@@ -68,6 +68,7 @@ binderhub_interact_text          : "Interact"  # The text that interact buttons 
 # Thebelab settings
 use_thebelab_button              : true  # If 'true', display a button to allow in-page running code cells with Thebelab
 thebelab_button_text             : "Thebelab"  # The text to display inside the Thebelab initialization button
+codemirror_theme                 : "abcdef"  # Theme for codemirror cells, for options see https://codemirror.net/doc/manual.html#config
 
 # Download settings
 use_download_button              : true  # If 'true', display a button to download a zip file for the notebook
@@ -79,7 +80,7 @@ download_button_text             : "Download" # The text that download buttons w
 # Bibliography and citation settings. See https://github.com/inukshuk/jekyll-scholar#configuration for options
 scholar:
   style: apa
-  
+
 #######################################################################################
 # Option to add a Goggle analytics tracking code
 

--- a/jupyter_book/book_template/_includes/js/thebelab.html
+++ b/jupyter_book/book_template/_includes/js/thebelab.html
@@ -15,7 +15,7 @@
       }
     }
 </script>
-<script src="https://unpkg.com/thebelab@0.3.3/lib/index.js"></script>
+<script src="https://unpkg.com/thebelab@0.4.0/lib/index.js"></script>
 <script>
     /**
      * Add attributes to Thebelab blocks

--- a/jupyter_book/book_template/_includes/js/thebelab.html
+++ b/jupyter_book/book_template/_includes/js/thebelab.html
@@ -7,6 +7,9 @@
         repo: '{{ site.binder_repo_org }}/{{ site.binder_repo_name }}',
         ref: '{{ site.binder_repo_branch }}',
       },
+      codeMirrorConfig: {
+        theme: "{{ site.codemirror_theme }}"
+      }
       kernelOptions: {
         name: '{% if page.kernel_name %}{{ page.kernel_name }}{% else %}python3{% endif %}',
       }


### PR DESCRIPTION
This adds the codemirror theme as a configuration option - we can't merge this until thebelab cuts a new release that we can use from the CDN.