### PR TITLE
Adding download links for the notebook files

### DIFF
--- a/jupyter_book/book_template/_config.yml
+++ b/jupyter_book/book_template/_config.yml
@@ -70,7 +70,7 @@ use_thebelab_button              : true  # If 'true', display a button to allow 
 thebelab_button_text             : "Thebelab"  # The text to display inside the Thebelab initialization button
 
 # Download settings
-use_download_button              : true  # If 'true', display a button to download a copy of the notebook
+use_download_button              : true  # If 'true', display a button to download a zip file for the notebook
 download_button_text             : "Download" # The text that download buttons will contain
 
 #######################################################################################
@@ -124,7 +124,6 @@ collections:
 # The following items will not be processed, by default. Create a custom list
 # to override the default setting.
 exclude:
-  - content/
   - scripts/
   - Gemfile
   - Gemfile.lock

--- a/jupyter_book/book_template/_config.yml
+++ b/jupyter_book/book_template/_config.yml
@@ -69,6 +69,9 @@ binderhub_interact_text          : "Interact"  # The text that interact buttons 
 use_thebelab_button              : true  # If 'true', display a button to allow in-page running code cells with Thebelab
 thebelab_button_text             : "Thebelab"  # The text to display inside the Thebelab initialization button
 
+# Download settings
+use_download_button              : true  # If 'true', display a button to download a copy of the notebook
+download_button_text             : "Download" # The text that download buttons will contain
 
 #######################################################################################
 # Jupyter book extensions and additional features

--- a/jupyter_book/book_template/_includes/buttons.html
+++ b/jupyter_book/book_template/_includes/buttons.html
@@ -1,8 +1,8 @@
 {% if page.interact_link %}
 <div class="buttons">
+{% include buttons/download.html %}
 {% include buttons/thebelab.html %}
 {% include buttons/binder.html %}
 {% include buttons/jupyterhub.html %}
-{% include buttons/download.html %}
 </div>
 {% endif %}

--- a/jupyter_book/book_template/_includes/buttons.html
+++ b/jupyter_book/book_template/_includes/buttons.html
@@ -3,5 +3,6 @@
 {% include buttons/thebelab.html %}
 {% include buttons/binder.html %}
 {% include buttons/jupyterhub.html %}
+{% include buttons/download.html %}
 </div>
 {% endif %}

--- a/jupyter_book/book_template/_includes/buttons/download.html
+++ b/jupyter_book/book_template/_includes/buttons/download.html
@@ -1,0 +1,4 @@
+{% if site.use_download_button -%}
+<a href="{{ site.baseurl }}/{{ page.download_link }}">
+<button id="interact-button-download" class="interact-button">{{ site.download_button_text }}</button>
+{% endif %}

--- a/jupyter_book/book_template/_includes/buttons/download.html
+++ b/jupyter_book/book_template/_includes/buttons/download.html
@@ -1,4 +1,4 @@
 {% if site.use_download_button -%}
-<a href="{{ site.baseurl }}/{{ page.download_link }}">
+<a href="{{ page.interact_link | relative_url }}" download>
 <button id="interact-button-download" class="interact-button">{{ site.download_button_text }}</button>
 {% endif %}

--- a/jupyter_book/book_template/content/guide/04_faq.md
+++ b/jupyter_book/book_template/content/guide/04_faq.md
@@ -30,6 +30,14 @@ jupyter-book create -h
 You should check out the content in your upgraded book to make sure it looks correct, then
 commit the changes to your repository.
 
+## Does the book behave differently depending on the browser?
+
+Maybe - Jupyter Book does use some features that might have different behaviors in
+some browsers. For example, Safari [tends to treat downloadable objects](https://github.com/jupyter/jupyter-book/pull/104#issuecomment-462461188)
+differently for some reason.
+
+The two browsers on which Jupyter Book should always behave as expected are
+**Firefox** and **Chrome**.
 
 ## Why isn't my math showing up properly?
 
@@ -46,7 +54,7 @@ be included in this script, please open an issue
 
 ## How can I include interactive Plotly figures?
 
-To display interactive [Plotly](https://plot.ly/python/) figures, they must 
+To display interactive [Plotly](https://plot.ly/python/) figures, they must
 first be generated in a Jupyter notebook using the [offline mode](https://plot.ly/python/offline/).
 You must then plot the figure with `plotly.offline.plot()`, which generates an HTML file (`plotly.offline.iplot()` does not),
 and then load the HTML into the notebook with `display(HTML('file.html'))` prior to saving your *.ipynb file.

--- a/jupyter_book/book_template/scripts/clean.py
+++ b/jupyter_book/book_template/scripts/clean.py
@@ -1,4 +1,4 @@
-"""A helper script to "clean up" all of your generated markdown, zip, and HTML files."""
+"""A helper script to "clean up" all of your generated markdown and HTML files."""
 import shutil as sh
 import os.path as op
 

--- a/jupyter_book/book_template/scripts/clean.py
+++ b/jupyter_book/book_template/scripts/clean.py
@@ -1,5 +1,4 @@
-"""A helper script to "clean up" all of your notebooks and
-generated markdown files."""
+"""A helper script to "clean up" all of your generated markdown, zip, and HTML files."""
 import shutil as sh
 import os.path as op
 

--- a/jupyter_book/build.py
+++ b/jupyter_book/build.py
@@ -9,7 +9,6 @@ from nbclean import NotebookCleaner
 from tqdm import tqdm
 import numpy as np
 from glob import glob
-from zipfile import ZipFile
 from uuid import uuid4
 import argparse
 from jupyter_book.utils import print_message_box

--- a/jupyter_book/build.py
+++ b/jupyter_book/build.py
@@ -9,6 +9,7 @@ from nbclean import NotebookCleaner
 from tqdm import tqdm
 import numpy as np
 from glob import glob
+from zipfile import ZipFile
 from uuid import uuid4
 import argparse
 from jupyter_book.utils import print_message_box
@@ -120,6 +121,11 @@ def build_book():
     PATH_TEMPLATE = args.template if args.template is not None else op.join(PATH_BOOK, 'scripts', 'templates', 'jekyllmd.tpl')
     PATH_IMAGES_FOLDER = op.join(PATH_BOOK, '_build', 'images')
     BUILD_FOLDER = op.join(PATH_BOOK, BUILD_FOLDER_NAME)
+    DOWNLOADS_FOLDER = op.join(PATH_BOOK, '_build', 'downloads')
+
+    # Make sure our downloads folder exists
+    if not op.exists(DOWNLOADS_FOLDER):
+        os.makedirs(DOWNLOADS_FOLDER)
 
     ###############################################################################
     # Read in textbook configuration
@@ -251,6 +257,14 @@ def build_book():
 
             check_call(call)
             os.remove(tmp_notebook)
+
+            ###############################################################################
+            # Copy downloadable version of notebook, if requested
+            if site_yaml.get('use_download_button', True):
+                nb_name = op.basename(path_url_page)
+                path_zipfile = op.join(DOWNLOADS_FOLDER, nb_name.split('.')[0] + '.zip')
+                ZipFile(path_zipfile, mode='w').write(path_url_page, nb_name)
+
         elif path_url_page.endswith('.md'):
             # If a non-notebook file, just copy it over.
             # If markdown we'll add frontmatter later
@@ -287,6 +301,12 @@ def build_book():
             interact_path = CONTENT_FOLDER_NAME + '/' + path_url_page.split(CONTENT_FOLDER_NAME+'/')[-1]
             yaml_fm += ['interact_link: {}'.format(interact_path)]
             yaml_fm += ["kernel_name: {}".format(kernel_name)]
+            if site_yaml.get('use_download_button', True):
+                # Add download metadata if we need it
+                download_path = 'downloads/' + path_url_page.split('/')[-1].split('.')[0] + '.zip'
+                yaml_fm += ['download_link: {}'.format(download_path)]
+
+        # Page metadata
         yaml_fm += ["title: '{}'".format(title)]
         yaml_fm += ['prev_page:']
         yaml_fm += ['  url: {}'.format(url_prev_page)]

--- a/jupyter_book/build.py
+++ b/jupyter_book/build.py
@@ -121,11 +121,6 @@ def build_book():
     PATH_TEMPLATE = args.template if args.template is not None else op.join(PATH_BOOK, 'scripts', 'templates', 'jekyllmd.tpl')
     PATH_IMAGES_FOLDER = op.join(PATH_BOOK, '_build', 'images')
     BUILD_FOLDER = op.join(PATH_BOOK, BUILD_FOLDER_NAME)
-    DOWNLOADS_FOLDER = op.join(PATH_BOOK, '_build', 'downloads')
-
-    # Make sure our downloads folder exists
-    if not op.exists(DOWNLOADS_FOLDER):
-        os.makedirs(DOWNLOADS_FOLDER)
 
     ###############################################################################
     # Read in textbook configuration
@@ -258,13 +253,6 @@ def build_book():
             check_call(call)
             os.remove(tmp_notebook)
 
-            ###############################################################################
-            # Copy downloadable version of notebook, if requested
-            if site_yaml.get('use_download_button', True):
-                nb_name = op.basename(path_url_page)
-                path_zipfile = op.join(DOWNLOADS_FOLDER, nb_name.split('.')[0] + '.zip')
-                ZipFile(path_zipfile, mode='w').write(path_url_page, nb_name)
-
         elif path_url_page.endswith('.md'):
             # If a non-notebook file, just copy it over.
             # If markdown we'll add frontmatter later
@@ -301,10 +289,6 @@ def build_book():
             interact_path = CONTENT_FOLDER_NAME + '/' + path_url_page.split(CONTENT_FOLDER_NAME+'/')[-1]
             yaml_fm += ['interact_link: {}'.format(interact_path)]
             yaml_fm += ["kernel_name: {}".format(kernel_name)]
-            if site_yaml.get('use_download_button', True):
-                # Add download metadata if we need it
-                download_path = 'downloads/' + path_url_page.split('/')[-1].split('.')[0] + '.zip'
-                yaml_fm += ['download_link: {}'.format(download_path)]
 
         # Page metadata
         yaml_fm += ["title: '{}'".format(title)]


### PR DESCRIPTION
This riffs off of https://github.com/jupyter/jupyter-book/pull/38 which @tomdonoghue pioneered getting a download link to work.

In that PR we were using a Zip file to download because it seemed like that was the only way to get the file to "auto" download. I found a blog post (https://www.philowen.co/blog/force-a-file-to-download-when-link-is-clicked/) that showed how to make the file automatically download even if it's an ipynb file. So, this PR does two things:

1. Adds @tomdonoghue 's commit that adds the download + zip functionality
2. Adds one more commit that strips some of this away and uses the interact link path to directly download the notebook file.

I still think that it could be a good idea to use zip files, but for now since we were only downloading the single notebook file anyway, this seems like a much simpler path that we can build upon. @tomdonoghue what do you think?