### PR TITLE
update link of the markdown version of guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Here are a few links of interest:
 
 * **[A demo of the hosted textbook](http://jupyter.org/jupyter-book/ )**
 * **[A short guide to deploying your own textbook](https://jupyter.org/jupyter-book/guide/01_overview)**
-* **[The markdown version of the guide in this repo](content/guide/)**
+* **[The markdown version of the guide in this repo](jupyter_book/book_template/content/guide/)**
 
 ## Explore this book
 


### PR DESCRIPTION
The current link for the markdown version of guide is not working. Hence updated the link.