### PR TITLE
Fix broken notebook links

### DIFF
--- a/jupyter_book/minimal/content/features/notebooks.ipynb
+++ b/jupyter_book/minimal/content/features/notebooks.ipynb
@@ -10,7 +10,7 @@
     "in a Jupyter Notebook in the `notebooks/` folder of the repository. This means that we can include\n",
     "code blocks and their outputs, and export them to Jekyll markdown.\n",
     "\n",
-    "**You can find the original notebook for this page [at this address](https://github.com/jupyter/textbooks-with-jupyter/blob/master/notebooks/introduction/notebooks.ipynb)**\n",
+    "**You can find the original notebook for this page [at this address](https://github.com/jupyter/jupyter-book/blob/master/jupyter_book/minimal/content/features/notebooks.ipynb)**\n",
     "\n",
     "## Markdown + notebooks\n",
     "\n",
@@ -104,7 +104,7 @@
     "## Removing content before publishing\n",
     "\n",
     "You can also remove some content before publishing your book to the web. For example,\n",
-    "in [the original notebook](https://github.com/jupyter/jupyter-book/blob/master/notebooks/introduction/notebooks.ipynb) there\n",
+    "in [the original notebook](https://github.com/jupyter/jupyter-book/blob/master/jupyter_book/minimal/content/features/notebooks.ipynb) there\n",
     "used to be a cell below..."
    ]
   },
@@ -143,7 +143,7 @@
     "You can also **remove only the code** so that images and other output still show up.\n",
     "\n",
     "Below we'll *only* display an image. It was generated with Python code in a cell,\n",
-    "which you can [see in the original notebook](https://github.com/jupyter/jupyter-book/blob/master/notebooks/introduction/notebooks.ipynb)"
+    "which you can [see in the original notebook](https://github.com/jupyter/jupyter-book/blob/master/jupyter_book/minimal/content/features/notebooks.ipynb)"
    ]
   },
   {
@@ -179,7 +179,7 @@
    "metadata": {},
    "source": [
     "And here we'll *only* display a Pandas DataFrame. Again, this was generated with Python code\n",
-    "from [this original notebook](https://github.com/jupyter/textbooks-with-jupyter/blob/master/notebooks/introduction/notebooks.ipynb)."
+    "from [this original notebook](https://github.com/jupyter/jupyter-book/blob/master/jupyter_book/minimal/content/features/notebooks.ipynb)."
    ]
   },
   {


### PR DESCRIPTION
The links to the raw notebook were incorrect in one of the pages of the documentation for jupyter-book. This PR fixes those links.