### PR TITLE
make sure jupyter-book is included in the binder build

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -ex
+
+# install jupyter-book
+cd ..
+python setup.py install


### PR DESCRIPTION
It seems like jupyter book is not installed in the binder build. The postBuild script should do this explicitly and fix #166 