### PR TITLE
Ask if kernelspec exists in metadata

### DIFF
--- a/jupyter_book/build.py
+++ b/jupyter_book/build.py
@@ -218,7 +218,8 @@ def build_book(path_book, path_toc_yaml=None, config_file=None,
         kernel_name = ''
         if path_url_page.endswith('.ipynb'):
             data = nbf.read(path_url_page, nbf.NO_CONVERT)
-            kernel_name = data['metadata']['kernelspec']['name']
+            if 'metadata' in data and 'kernelspec' in data['metadata']:
+                kernel_name = data['metadata']['kernelspec']['name']
             has_widgets = "true" if any("interactive" in cell['metadata'].get('tags', []) for cell in data['cells']) else "false"
 
         ############################################


### PR DESCRIPTION
build.py reads the kernel name from the jupyter notebooks metadata. Apparently, both the metadata and the kernelspec nodes are optional in the Jupyter notebook format, so we should make sure that they exist before we attempt to read them.

Fixes #195