### PR TITLE
Ensure UTF-8 Encoding When Building Book

### DIFF
--- a/jupyter_book/build.py
+++ b/jupyter_book/build.py
@@ -322,8 +322,8 @@ def build_book(path_book, path_toc_yaml=None, config_file=None,
         yaml_fm = [ii + '\n' for ii in yaml_fm]
         lines = yaml_fm + lines
 
-        # Write the result
-        with open(path_new_file, 'w') as ff:
+        # Write the result as UTF-8.
+        with open(path_new_file, 'w', encoding='utf8') as ff:
             ff.writelines(lines)
         n_built_files += 1
 


### PR DESCRIPTION
An addendum to #187 to ensure UTF-8 encoding when writing in `build_book`.  This resolves a `UnicodeDecodeError` [when building books](https://github.com/jupyter/jupyter-book/issues/137#issuecomment-501008281) in a conda 4.6.14 / Python 3.6.8 environment.