### PR TITLE
use celltagpreprocessor to remove parts of cells and updating running code module

### DIFF
--- a/jupyter_book/book_template/content/features/hiding.ipynb
+++ b/jupyter_book/book_template/content/features/hiding.ipynb
@@ -269,6 +269,43 @@
     "This markdown cell will be hidden from users, though they can click to make it\n",
     "appear!"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Removing empty cells\n",
+    "\n",
+    "You don't need to do anything to remove empty cells from your pages.\n",
+    "Jupyter Book will remove these automatically. Any cell with *only*\n",
+    "whitespace will be removed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For example, in the notebook for this page there are two cells above this one. One\n",
+    "cell with whitespace, and another cell with a few line-breaks. Both are gone in\n",
+    "the final output."
+   ]
   }
  ],
  "metadata": {
@@ -287,7 +324,14 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.7.3"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {},
+    "version_major": 2,
+    "version_minor": 0
+   }
   }
  },
  "nbformat": 4,

--- a/jupyter_book/book_template/scripts/templates/html.tpl
+++ b/jupyter_book/book_template/scripts/templates/html.tpl
@@ -1,26 +1,10 @@
 {% extends 'basic.tpl' %}
 
-{% block codecell %}
-{% if 'remove_cell' not in cell.metadata.tags and 'removecell' not in cell.metadata.tags %}
-{{ super() }}
-{% endif %}
-{%- endblock codecell %}
-
-{% block markdowncell %}
-{% if 'remove_cell' not in cell.metadata.tags and 'removecell' not in cell.metadata.tags %}
-{{ super() }}
-{% endif %}
-{%- endblock markdowncell %}
-
 <!-- Remove input cells if they're empty. Same as nbconvert basic w/ the extra class -->
 {% block input_group %}
-{%- if 'remove_input' not in cell.metadata.tags %}
-{%- if cell.source != '' %}
 <div class="jb_input{% if 'hide_input' in cell.metadata.tags or 'hidecode' in cell.metadata.tags %} hidecode{% endif %}" >
 {{ super() }}
 </div>
-{% endif %}
-{% endif %}
 {% endblock input_group %}
 
 

--- a/jupyter_book/run.py
+++ b/jupyter_book/run.py
@@ -2,26 +2,36 @@
 to ensure that all of your notebooks run, and that the output
 contained in the notebook files is up-to-date."""
 from glob import glob
-from subprocess import run
 from tqdm import tqdm
-
+import nbformat as nbf
+from nbconvert.preprocessors import ExecutePreprocessor
 import os.path as op
 
 
 def run_book(path, kernel_name='python3'):
-
+    "Run a collection of notebooks. Each will be run in-place."
     print("Running all notebooks underneath {}".format(path))
     ipynb_files = glob(op.join(path, '**', '*.ipynb'), recursive=True)
 
     failed_files = []
     for ifile in tqdm(ipynb_files):
-        call = 'jupyter nbconvert --inplace --ExecutePreprocessor.kernel_name={} --to notebook --execute {}'.format(
-            kernel_name, ifile)
+        ntbk = nbf.read(ifile, nbf.NO_CONVERT)
         try:
-            run(call.split(), check=True)
+            ntbk = run_ntbk(ntbk, op.dirname(ifile))
+            nbf.write(ntbk, ifile)
         except Exception:
             failed_files.append(ifile)
 
     print('Failing files:')
     for ifile in failed_files:
         print(ifile)
+
+
+def run_ntbk(ntbk, path_directory, timeout=600, kernel_name=None):
+    """Run a notebook node."""
+    if kernel_name is None:
+        kernel_name = ntbk.get('metadata', {}).get('kernelspec', {}).get('name')
+
+    ep = ExecutePreprocessor(timeout=timeout, kernel_name=kernel_name)
+    ntbk, _ = ep.preprocess(ntbk, {'metadata': {'path': path_directory}})
+    return ntbk

--- a/jupyter_book/utils.py
+++ b/jupyter_book/utils.py
@@ -112,7 +112,7 @@ def _prepare_url(url):
     return url
 
 
-def _clean_notebook_cells(ntbk):
+def _clean_markdown_cells(ntbk):
     """Clean up cell text of an nbformat NotebookNode."""
     # Remove '#' from the end of markdown headers
     for cell in ntbk.cells:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,5 @@ tqdm
 numpy
 pyyaml
 nbformat
-nbclean
 setuptools
 jupyter_contrib_nbextensions


### PR DESCRIPTION
This PR does a few things:

* Removes the use of a custom template for removing inputs/outputs/etc because we discovered the nbconvert "TagRemovePreprocessor"
* Fixes up the "run a notebook" code to use the ExecutePreprocessor
* Uses the RegExpRemovePreprocessor for removing empty cells
* As a result, we no longer need `nbclean` so we're removing that dependency (which is actually pretty heavy)
* One side effect is that `stderr` will now show up in the output, though we can take that out later pretty easily