### PR TITLE
fixing double math printing

### DIFF
--- a/jupyter_book/book_template/_includes/js/print.html
+++ b/jupyter_book/book_template/_includes/js/print.html
@@ -2,12 +2,23 @@
 <script src="{{ '/assets/js/print.min.js' | relative_url }}"  type="text/javascript"></script>
 <script>
 printContent = () => {
+    // MathJax displays a second version of any math for assistive devices etc.
+    // This prevents double-rendering in the PDF output.
+    var ignoreAssistList = [];
+    assistives = document.querySelectorAll('.MathJax_Display span.MJX_Assistive_MathML').forEach((element, index) => {
+        var thisId = 'MathJax-assistive-' + index.toString();
+        element.setAttribute('id', thisId);
+        ignoreAssistList.push(thisId)
+    });
+
+    // Print the actual content object
     printJS({
         printable: 'textbook_content',
         type: 'html',
         css: "{{ site.css_url | relative_url }}/styles.css",
         scanStyles: false,
         targetStyles: ["*"],
+        ignoreElements: ignoreAssistList
     })
 };
 


### PR DESCRIPTION
I *think* this will fix the double printing of math. The problem was that there was a second printing of math to help assistive devices, so this makes PrintJS ignore that second set of math