### PR TITLE
fixing jupytext markdown inconsistencies

### DIFF
--- a/jupyter_book/book_template/content/features/markdown.md
+++ b/jupyter_book/book_template/content/features/markdown.md
@@ -1,3 +1,18 @@
+---
+jupyter:
+  jupytext:
+    formats: md
+    text_representation:
+      extension: .md
+      format_name: markdown
+      format_version: '1.1'
+      jupytext_version: 1.2.1
+  kernelspec:
+    display_name: Python 3
+    language: python
+    name: python3
+---
+
 # Creating book content
 
 The two kinds of files that contain course content are:
@@ -10,6 +25,7 @@ Each are contained in the `content/` folder and referenced from `_data/toc.yml`.
 If the file is markdown, it will be copied over with front-matter YAML added so
 that Jekyll can parse it.
 
+<!-- #region -->
 ```python
 print("Python (and any language-specific) code still works as expected")
 ```
@@ -17,6 +33,7 @@ print("Python (and any language-specific) code still works as expected")
 ```
 As does non-language code.
 ```
+<!-- #endregion -->
 
 ## Page navigation Table of Contents
 
@@ -45,6 +62,7 @@ P(A_1 \cup A_2 \cup A_3) ~ = ~ P(B \cup A_3) &= ~ P(B) + P(A_3) - P(BA_3) \\
 
 And here is the code that was used to generate it:
 
+<!-- #region -->
 ```python
 \begin{align*}
 P(A_1 \cup A_2 \cup A_3) ~ = ~ P(B \cup A_3) &= ~ P(B) + P(A_3) - P(BA_3) \\
@@ -52,6 +70,7 @@ P(A_1 \cup A_2 \cup A_3) ~ = ~ P(B \cup A_3) &= ~ P(B) + P(A_3) - P(BA_3) \\
 &= ~ \sum_{i=1}^3 P(A_i) - \mathop{\sum \sum}_{1 \le i < j \le 3} P(A_iA_j) + P(A_1A_2A_3)
 \end{align*}
 ```
+<!-- #endregion -->
 
 <!-- #region {"tags": ["popout"]} -->
 **Note**: If you print your page (using the print button), then mathematics may not show


### PR DESCRIPTION
This changes the logic for reading in text files in order to be more consistent about how markdown files are handled.

The current situation:

Any content file will be read in with jupytext. This is awesome, with the exception that some people's code **blocks** may be incorrectly parsed as code **cells** in the markdown files. In the short term, it'd be tricky to avoid that behavior from within juyptext

This PR's approach:

If a `.markdown` or `.md` file is found, read it in to memory. First see if it has any YAML header.

* If so, check if `yaml.get('jupyter').get('jupytext')` returns None.
    * If so, or if there was no YAML, then assume it is a "regular" markdown file and just dump it into a single NotebookNode markdown cell. 
    * If not (AKA, there's something in `yaml.jupyter.jupytext`) then use `jupytext.reads` to load in the notebook.

The main assumption this is making is that jupytext files will always have a YAML header with something in the `jupyter.jupytext` field, while non-jupytext markdown files will not. That seems like a reasonable assumption to make.

@mwouts what do you think about this implementation? It's a bit hacky, but at least in the short-term it solves the markdown parsing differences problem. Perhaps longer-term we can figure out a way to solve this more gracefully!