### PR TITLE
Load thebelab asynchronously

### DIFF
--- a/jupyter_book/book_template/_includes/js/thebelab.html
+++ b/jupyter_book/book_template/_includes/js/thebelab.html
@@ -19,7 +19,7 @@
       }
     }
 </script>
-<script src="https://unpkg.com/thebelab@0.4.0/lib/index.js"></script>
+<script src="https://unpkg.com/thebelab@0.4.0/lib/index.js" async></script>
 <script>
     /**
      * Add attributes to Thebelab blocks


### PR DESCRIPTION
Adds an `async` attribute to the script tag to load thebelab
asynchronously. This allows the DOM to load while loading thebelab in
the background.

How I tested this:

1. Load
   http://127.0.0.1:4000/jupyter-book/01/3/Plotting_the_Classics.html
2. Hard refresh the page. This results in an average DOMContentLoaded
   time of 1.1s.
3. Add `async` attribute and hard refresh the page again. This results
   in an average DOMContentLoaded time of 660ms, a 40% speedup.
4. To verify that this still loads thebelab, I ran a few cells on this
   page using thebelab after loading asynchronously.