### PR TITLE
adding right toc showing when there's no sidebar content

### DIFF
--- a/jupyter_book/book_template/_includes/js/tocbot.html
+++ b/jupyter_book/book_template/_includes/js/tocbot.html
@@ -6,6 +6,14 @@ const initToc = () => {
     return
   }
 
+  // Check whether we have any sidebar content. If not, then show the sidebar earlier.
+  var SIDEBAR_CONTENT_TAGS = ['.tag_full_width', '.tag_popout'];
+  var sidebar_content_query = SIDEBAR_CONTENT_TAGS.join(', ')
+  if (document.querySelectorAll(sidebar_content_query).length === 0) {
+    document.querySelector('nav.onthispage').classList.add('no_sidebar_content')
+  }
+
+  // Initialize the TOC bot
   tocbot.init({
     tocSelector: 'nav.onthispage',
     contentSelector: '.c-textbook__content',

--- a/jupyter_book/book_template/_sass/components/_components.textbook.scss
+++ b/jupyter_book/book_template/_sass/components/_components.textbook.scss
@@ -106,7 +106,6 @@ $book-background-color: white;
     // Show right TOC at laptop size
     display: block;
   }
-
 }
 
 .js-show-sidebar {

--- a/jupyter_book/book_template/_sass/components/_components.textbook__sidebar-right.scss
+++ b/jupyter_book/book_template/_sass/components/_components.textbook__sidebar-right.scss
@@ -47,6 +47,13 @@ aside.sidebar__right {
             opacity: 100;
             height: auto;
         }
+
+        @include mq($from: laptop) {
+            &.no_sidebar_content {
+              opacity: 100;
+              height: auto;
+            }
+        }
     }
 
     &:hover nav {


### PR DESCRIPTION
This adds a tiny javascript snippet to check whether a page has any sidebar content, and if not, then the TOC will show up in narrower screens than normal. This should prevent as many cases where there is a lot of white-space to the right for unclear reasons because no sidebar content is present.