### PR TITLE
Set a blank excerpt for all pages

### DIFF
--- a/jupyter_book/book_template/_config.yml
+++ b/jupyter_book/book_template/_config.yml
@@ -111,6 +111,7 @@ defaults:
       toc: true
       toc_label: "  On this page"
       toc_icon: "list-ul"
+      excerpt: ''
 
 favicon_path: "images/logo/favicon.ico"
 

--- a/jupyter_book/book_template/_includes/fb_tags.html
+++ b/jupyter_book/book_template/_includes/fb_tags.html
@@ -1,7 +1,7 @@
 <meta property="og:url"         content="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url  | relative_url }}" />
 <meta property="og:type"        content="article" />
 <meta property="og:title"       content="{% if page.title %}{{ page.title | escape }}{% else %}{{ site.title | escape }}{% endif %}" />
-<meta property="og:description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}" />
+<meta property="og:description" content="{{ page.content | strip_html | strip_newlines | truncate: 160 }}" />
 <meta property="og:image"       content="{{ site.textbook_logo | absolute_url }}" />
 
 <meta name="twitter:card" content="summary">

--- a/jupyter_book/book_template/_includes/head.html
+++ b/jupyter_book/book_template/_includes/head.html
@@ -4,7 +4,7 @@
   <meta name="viewport" content="width=device-width,minimum-scale=1">
 
   <title>{% if page.title %}{{ page.title | escape }}{% else %}{{ site.title | escape }}{% endif %}</title>
-  <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
+  <meta name="description" content="{{ page.content | strip_html | strip_newlines | truncate: 160 }}">
 
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url | relative_url }}">
   <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url | relative_url }}">

--- a/jupyter_book/book_template/_includes/metadata.json
+++ b/jupyter_book/book_template/_includes/metadata.json
@@ -1,16 +1,11 @@
 {
   "@context": "http://schema.org",
   "@type": "NewsArticle",
-  "mainEntityOfPage":
-    "{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}",
-  "headline":
-    "{% if page.title %}{{ page.title | escape }}{% else %}{{ site.title | escape }}{% endif %}",
-  "datePublished":
-    "{% if page.date %}{{ page.date | date_to_xmlschema }}{% else %}{{ site.time | date_to_xmlschema }}{% endif %}",
-  "dateModified":
-    "{% if page.date %}{{ page.date | date_to_xmlschema }}{% else %}{{ site.time | date_to_xmlschema }}{% endif %}",
-  "description":
-    "{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}",
+  "mainEntityOfPage": "{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}",
+  "headline": "{% if page.title %}{{ page.title | escape }}{% else %}{{ site.title | escape }}{% endif %}",
+  "datePublished": "{% if page.date %}{{ page.date | date_to_xmlschema }}{% else %}{{ site.time | date_to_xmlschema }}{% endif %}",
+  "dateModified": "{% if page.date %}{{ page.date | date_to_xmlschema }}{% else %}{{ site.time | date_to_xmlschema }}{% endif %}",
+  "description": "{{ page.content | strip_html | strip_newlines | truncate: 160 }}",
   "author": {
     "@type": "Person",
     "name": "{{ site.author }}"


### PR DESCRIPTION
This commit sets a blank Jekyll excerpt as the default for all pages
([docs on excerpts][1]). Without this configuration, Jekyll tries to
generate a page excerpt using the first paragraph of each page. However,
we do not use the page excerpt anywhere in this project (since we don't
have an equivalent of a "list of all blog posts" page). Setting a blank
excerpt decreases website build time.

More importantly, in a later commit I plan to wrap HTML generated from a
Jupyter notebook in a `{% raw %}` tag ([docs][2]). Without this tag,
complicated LaTeX will break Jekyll builds. However, when Jekyll tries
to generate page excerpts, it breaks because the excerpt contains the
`{% raw %}` tag but not the `{% endraw %}` tag.

[1]: https://jekyllrb.com/docs/posts/#post-excerpts
[2]: https://shopify.github.io/liquid/tags/raw/