### PR TITLE
Don't use quotes for user-entered YAML entries

### DIFF
--- a/jupyter_book/build.py
+++ b/jupyter_book/build.py
@@ -258,13 +258,16 @@ def build_book(path_book, path_toc_yaml=None, path_ssg_config=None,
         yaml_fm += ["has_widgets: {}".format(has_widgets)]
 
         # Page metadata
-        yaml_fm += ["title: '{}'".format(title)]
+        yaml_fm += ["title: |-"]
+        yaml_fm += ["  {}".format(title)]
         yaml_fm += ['prev_page:']
         yaml_fm += ['  url: {}'.format(url_prev_page)]
-        yaml_fm += ["  title: '{}'".format(prev_file_title)]
+        yaml_fm += ["  title: |-"]
+        yaml_fm += ["    {}".format(prev_file_title)]
         yaml_fm += ['next_page:']
         yaml_fm += ['  url: {}'.format(url_next_page)]
-        yaml_fm += ["  title: '{}'".format(next_file_title)]
+        yaml_fm += ["  title: |-"]
+        yaml_fm += ["    {}".format(next_file_title)]
 
         # Add back any original YaML, and end markers
         yaml_fm += yaml_orig

--- a/jupyter_book/build.py
+++ b/jupyter_book/build.py
@@ -258,6 +258,8 @@ def build_book(path_book, path_toc_yaml=None, path_ssg_config=None,
         yaml_fm += ["has_widgets: {}".format(has_widgets)]
 
         # Page metadata
+        # Use YAML block scalars for titles so that people can use special characters
+        # See http://blogs.perl.org/users/tinita/2018/03/strings-in-yaml---to-quote-or-not-to-quote.html
         yaml_fm += ["title: |-"]
         yaml_fm += ["  {}".format(title)]
         yaml_fm += ['prev_page:']


### PR DESCRIPTION
Because we used to wrap page title entries with quotes in YAML
front-matter, pages with a quote in the name would cause Jekyll to error
out ([like this page titled "What's in a name?"][1]).

This commit uses [YAML Block Scalars][2] to give users the greatest
flexibility when naming book sections. Section names can now contain
single quotes, double quotes, and colons.

To test this:

1. I edited `jupyter_book/book_template/_data/toc.yml`, changing the
   page titled `Jupyter notebooks` to `"Sam's Cool Title: Notebooks!"`.
   I verified that building the website does not break at either
   `jupyter-book build` or the `jekyll build` step.
2. I opened http://127.0.0.1:4001/jupyter-book/features/notebooks.html
   and verified that the sidebar had the updated title.
3. I opened http://127.0.0.1:4001/jupyter-book/features/hiding.html and
   verified that the previous page button at the bottom of the page had
   `Sam's Cool Title: Notebooks!` as the previous page's title.

[1]: https://www.textbook.ds100.org/ch/01/lifecycle_students_3.html
[2]: http://blogs.perl.org/users/tinita/2018/03/strings-in-yaml---to-quote-or-not-to-quote.html