### PR TITLE
Wrap `jekyll-raw` cells with {% raw %}

### DIFF
--- a/jupyter_book/tests/site/content/tests/notebooks.ipynb
+++ b/jupyter_book/tests/site/content/tests/notebooks.ipynb
@@ -33,8 +33,13 @@
     "\\end{align*}\n",
     "$$\n",
     "\n",
-    "You should \\\\$Escape \\\\$your \\\\$dollar signs!\n",
-    "\n",
+    "You should \\\\$Escape \\\\$your \\\\$dollar signs!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Code blocks and image outputs\n",
     "\n",
     "Textbooks with Jupyter will also embed your code blocks and output in your site.\n",
@@ -95,6 +100,37 @@
    "metadata": {},
    "source": [
     "Note that the image above is captured and displayed by Jekyll."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The following two cells contains Python code and Markdown with multiple consecutive braces. Since the cells contain the `jekyll-raw` tag, the notebook should still build without errors."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "jekyll-raw"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "hello = '{{{world}}}'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "jekyll-raw"
+    ]
+   },
+   "source": [
+    "Here's a valid Python expression: `'{{{world}}}'`"
    ]
   },
   {
@@ -274,6 +310,7 @@
   }
  ],
  "metadata": {
+  "celltoolbar": "Tags",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",

--- a/jupyter_book/tests/test_create.py
+++ b/jupyter_book/tests/test_create.py
@@ -208,8 +208,8 @@ def test_notebook(tmpdir):
     with open(op.join(path_build_test, '_build', 'tests', 'notebooks.html'), 'r') as ff:
         lines = ff.readlines()
 
-    # Notebook-converted images work
-    assert is_in(lines, "../images/tests/notebooks_2_0.png")
+    # Notebook-converted images work (not checking number in case cell count changes)
+    assert is_in(lines, "../images/tests/notebooks_")
 
     # Input area classes are there
     assert is_in(lines, 'class="input_area')


### PR DESCRIPTION
In LaTeX and Python it is not uncommon to have Jekyll/Liquid keywords,
like the substrings `{{` or `}}`. To tell Jekyll not to process these
as Jekyll commands, users can give cells the tag `jekyll-raw`. The
generated HTML will be wrapped in a `{% raw %}` tag.

To test this, I did the following:

1. Added a Python cell to
   `./jupyter_book/book_template/content/features/notebooks.ipynb` with
   the code `'{{{hello}}}'`.
2. Checked that `make book build` fails.
3. Added the `jekyll-raw` tag to the cell.
4. Checked that `make book build` succeeds, and that
   http://127.0.0.1:4000/jupyter-book/features/notebooks.html has the
   Python code `'{{{hello}}}'`.