### PR TITLE
Changes to make work with `conda skeleton pypi jupyter-book`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
     name='jupyter-book',
     version=__version__,
     install_requires=install_packages,
+    include_package_data=True,
     python_requires='>=3.4',
     author='Project Jupyter Contributors',
     author_email='jupyter@googlegroups.com',


### PR DESCRIPTION
I tried to install this package using [conda skeleton](https://docs.conda.io/projects/conda-build/en/latest/user-guide/tutorials/build-pkgs-skeleton.html) ([see also](https://docs.conda.io/projects/conda-build/en/latest/resources/commands/conda-skeleton-pypi.html)) but ran into the error:

<details><summary>Traceback</summary>

```
Traceback (most recent call last):
  File "setup.py", line 17, in <module>
    with open('requirements.txt', 'r') as f:
FileNotFoundError: [Errno 2] No such file or directory: 'requirements.txt'
$PYTHONPATH = /var/folders/2b/mmgzz0qx6rvc_hgds3b0snjc0000gr/T/tmpwf3pkgfjconda_skeleton_jupyter-book-0.5.2.tar.gz/jupyter-book-0.5.2

Leaving build/test directories:
  Work:
 /opt/conda/miniconda3/conda-bld/skeleton_1568068075277/work 
  Test:
 /opt/conda/miniconda3/conda-bld/skeleton_1568068075277/test_tmp 
Leaving build/test environments:
  Test:
source activate  /opt/conda/miniconda3/conda-bld/skeleton_1568068075277/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol 
  Build:
source activate  /opt/conda/miniconda3/conda-bld/skeleton_1568068075277/_build_env 


Error: command failed: /opt/conda/miniconda3/conda-bld/skeleton_1568068075277/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_pla/bin/python setup.py install
```

</details>

It seems like (and I'm not really sure) that `conda build` isn't able to run `setup.py` because `requirements.txt` isn't included with the source distribution uploaded to PyPI. So I added a `MANIFEST.in` and an [extra `include_package_data` line in the call to `setup`](https://python-packaging.readthedocs.io/en/latest/non-code-files.html). But admittedly I'm not sure whether this is sufficient to fix the error, nor am I sure how to test locally whether this would fix the error (since it seems like `conda skeleton` must pull the package remotely from PyPI).

Anyway since there isn't yet a conda-forge conda package for this project (which is understandable, because it takes a really long time for PR's to staged-recipes to get looked at/reviewed, and even longer for them to get approved), ensuring that the PyPI distribution is properly configured to work with `conda skeleton pypi` seems like it would be a helpful intermediate step for users.