### PR TITLE
adding error message context to the build CLI command

### DIFF
--- a/jupyter_book/__init__.py
+++ b/jupyter_book/__init__.py
@@ -1,2 +1,11 @@
 """Build an online book using Jupyter Notebooks and Jekyll."""
-__version__ = "0.5.3dev0"
+import yaml
+import os.path as op
+import os
+
+# Load the version from the template Jupyter Book repository config
+path_yml = op.join(op.dirname(__file__), 'book_template', '_config.yml')
+with open(path_yml, 'r') as ff:
+    __version__ = yaml.safe_load(ff.read()).get(
+        "jupyter_book_version"
+    )

--- a/jupyter_book/book_template/_config.yml
+++ b/jupyter_book/book_template/_config.yml
@@ -146,4 +146,4 @@ plugins:
   - jekyll-scholar
 
 # Jupyter Book version - DO NOT CHANGE THIS. It is generated when a new book is created
-jupyter_book_version: INSERT
+jupyter_book_version: "0.5.3dev0"

--- a/jupyter_book/build.py
+++ b/jupyter_book/build.py
@@ -8,7 +8,7 @@ from uuid import uuid4
 import jupytext as jpt
 
 from .utils import (print_message_box, _split_yaml, _check_url_page, _prepare_toc,
-                    _prepare_url, _error, _file_newer_than)
+                    _prepare_url, _error, _file_newer_than, _check_book_versions)
 from .page import build_page
 
 # Defaults
@@ -100,6 +100,15 @@ def build_book(path_book, path_toc_yaml=None, path_ssg_config=None,
     overwrite : bool
         Whether to overwrite existing HTML files
     """
+    if not op.isdir(path_book):
+        raise _error(
+            "Could not find a Jupyter Book at the given location.\n"
+            "Double-check the path you've provided:\n"
+            "\n"
+            f"{path_book}"
+        )
+
+    _check_book_versions(path_book)
 
     PATH_IMAGES_FOLDER = op.join(path_book, '_build', 'images')
     BUILD_FOLDER = op.join(path_book, BUILD_FOLDER_NAME)

--- a/jupyter_book/commands/build.py
+++ b/jupyter_book/commands/build.py
@@ -5,7 +5,6 @@ import argparse
 
 from ..build import build_book
 from ..page import build_page
-from ..utils import _error
 
 DESCRIPTION = ("Convert a collection of Jupyter Notebooks into HTML "
                "suitable for a course textbook.")

--- a/jupyter_book/commands/build.py
+++ b/jupyter_book/commands/build.py
@@ -3,9 +3,9 @@ import os.path as op
 
 import argparse
 
-from .build import build_book
-from .page import build_page
-from .utils import _error
+from ..build import build_book
+from ..page import build_page
+from ..utils import _error
 
 DESCRIPTION = ("Convert a collection of Jupyter Notebooks into HTML "
                "suitable for a course textbook.")
@@ -52,13 +52,8 @@ def build():
 
     local_build = args.local_build
 
-    try:
-        build_book(PATH_BOOK, PATH_TOC_YAML, CONFIG_FILE,
-                   PATH_TEMPLATE, local_build, execute, overwrite)
-    except Exception as exc:
-        raise _error(
-            "ERROR!"
-        )
+    build_book(PATH_BOOK, PATH_TOC_YAML, CONFIG_FILE,
+               PATH_TEMPLATE, local_build, execute, overwrite)
 
 
 def page():

--- a/jupyter_book/commands/build.py
+++ b/jupyter_book/commands/build.py
@@ -3,8 +3,9 @@ import os.path as op
 
 import argparse
 
-from jupyter_book.build import build_book
-from jupyter_book.page import build_page
+from .build import build_book
+from .page import build_page
+from .utils import _error
 
 DESCRIPTION = ("Convert a collection of Jupyter Notebooks into HTML "
                "suitable for a course textbook.")
@@ -51,8 +52,13 @@ def build():
 
     local_build = args.local_build
 
-    build_book(PATH_BOOK, PATH_TOC_YAML, CONFIG_FILE,
-               PATH_TEMPLATE, local_build, execute, overwrite)
+    try:
+        build_book(PATH_BOOK, PATH_TOC_YAML, CONFIG_FILE,
+                   PATH_TEMPLATE, local_build, execute, overwrite)
+    except Exception as exc:
+        raise _error(
+            "ERROR!"
+        )
 
 
 def page():

--- a/jupyter_book/create.py
+++ b/jupyter_book/create.py
@@ -174,7 +174,7 @@ def new_book(path_out, content_folder, toc,
         # placeholders for users to change
         update_config(op.join(path_out, '_config.yml'), config)
 
-    # Add the Jupyter Book version fo the config
+    # Add the Jupyter Book version to the config
     yaml = YAML()
     with open(op.join(path_out, '_config.yml'), 'r') as ff:
         data = yaml.load(ff)

--- a/jupyter_book/tests/configs/config_wrongversion.yml
+++ b/jupyter_book/tests/configs/config_wrongversion.yml
@@ -1,0 +1,4 @@
+use_show_widgets_button: true
+use_thebelab_button: true
+use_download_button: true
+jupyter_book_version: "999.999"

--- a/jupyter_book/tests/configs/config_wrongversion.yml
+++ b/jupyter_book/tests/configs/config_wrongversion.yml
@@ -1,4 +1,0 @@
-use_show_widgets_button: true
-use_thebelab_button: true
-use_download_button: true
-jupyter_book_version: "999.999"

--- a/jupyter_book/tests/test_create.py
+++ b/jupyter_book/tests/test_create.py
@@ -203,11 +203,26 @@ def test_build(tmpdir):
     run(cmd, check=True)
 
     # Make sure a config with incorrect version raises an error
-    path_config_wrong_version = op.join(this_folder, 'configs', 'config_wrongversion.yml')
-    with pytest.raises(ValueError):
-        cmd = ["jupyter-book", 'build', path_build_test,
-               '--config', path_config_wrong_version]
+    path_config_built = op.join(path_build_test, "_config.yml")
+    # Read in our built config and update the version so it's a mismatch
+    with open(path_config_built, 'r') as ff:
+        config = yaml.load(ff)
+        # Store the old version so we can re-use it later
+        old_version = config['jupyter_book_version']
+        config['jupyter_book_version'] = 999.999
+
+    with open(path_config_built, 'w') as ff:
+        yaml.dump(config, ff)
+
+    # Now use the new config to build the book and it should error
+    with pytest.raises(CalledProcessError):
+        cmd = ["jupyter-book", 'build', path_build_test]
         run(cmd, check=True)
+
+    # Finally we'll re-update the config so that it has the the right version again
+    config['jupyter_book_version'] = old_version
+    with open(path_config_built, 'w') as ff:
+        yaml.dump(config, ff)
 
 
 def test_notebook(tmpdir):

--- a/jupyter_book/tests/test_create.py
+++ b/jupyter_book/tests/test_create.py
@@ -202,6 +202,13 @@ def test_build(tmpdir):
     cmd = ["jupyter-book", 'build', path_build_test]
     run(cmd, check=True)
 
+    # Make sure a config with incorrect version raises an error
+    path_config_wrong_version = op.join(this_folder, 'configs', 'config_wrongversion.yml')
+    with pytest.raises(ValueError):
+        cmd = ["jupyter-book", 'build', path_build_test,
+               '--config', path_config_wrong_version]
+        run(cmd, check=True)
+
 
 def test_notebook(tmpdir):
     path_build_test = op.join(tmpdir.dirpath(), 'tmp_test', 'test')

--- a/jupyter_book/utils.py
+++ b/jupyter_book/utils.py
@@ -4,7 +4,7 @@ import string
 import argparse
 import os
 import os.path as op
-from ruamel.yaml import YAML
+import yaml
 
 from . import __version__
 
@@ -146,10 +146,10 @@ def _check_book_versions(path_book):
     """Check whether the version of a book matches the version of the
     CLI that's building it."""
 
-    yaml = YAML()
-    config_version = yaml.load(op.join(path_book, "_config.yml")).get(
-        "jupyter_book_version"
-    )
+    with open(op.join(path_book, "_config.yml"), 'r') as ff:
+        config_version = yaml.safe_load(ff.read()).get(
+            "jupyter_book_version"
+        )
 
     if config_version is None:
         raise _error(
@@ -162,12 +162,14 @@ def _check_book_versions(path_book):
             f"The version of the book you are modifying doesn't match the\n"
             "version of the command-line tool that you're using. Please run\n"
             "\n"
-            "    jupyter-book upgrade {path_book} \n"
+            f"    jupyter-book upgrade {path_book} \n"
             "\n"
             "to upgrade your book to the CLI version.\n"
             "\n"
             f"This book's version: {config_version}\n"
-            f"Your CLI's version: {__version__}"
+            f"Your CLI's version: {__version__}\n"
+            "\n"
+            "See above for the error message."
         )
 
     return True

--- a/jupyter_book/utils.py
+++ b/jupyter_book/utils.py
@@ -4,49 +4,53 @@ import string
 import argparse
 import os
 import os.path as op
+from ruamel.yaml import YAML
+
+from . import __version__
 
 ##############################################################################
 # CLI utilities
 
 
 def print_color(msg, style):
-    endc = '\033[0m'
-    bcolors = dict(blue='\033[94m',
-                   green='\033[92m',
-                   orange='\033[93m',
-                   red='\033[91m',
-                   bold='\033[1m',
-                   underline='\033[4m')
+    endc = "\033[0m"
+    bcolors = dict(
+        blue="\033[94m",
+        green="\033[92m",
+        orange="\033[93m",
+        red="\033[91m",
+        bold="\033[1m",
+        underline="\033[4m",
+    )
     print(bcolors[style] + msg + endc)
 
 
 def print_message_box(msg):
-    border = '================================================================================'
-    print_color('\n\n' + border + '\n\n', 'green')
+    border = "================================================================================"
+    print_color("\n\n" + border + "\n\n", "green")
     print(msg)
-    print_color('\n\n' + border + '\n\n', 'green')
+    print_color("\n\n" + border + "\n\n", "green")
 
 
 def _error(msg):
-    msg = '\n\n\033[91m==========\033[0m\n{}\n\033[91m==========\033[0m\n'.format(
-        msg)
+    msg = "\n\n\033[91m==========\033[0m\n{}\n\033[91m==========\033[0m\n".format(msg)
     return ValueError(msg)
 
 
 def str2bool(msg):
-    if msg.lower() in ('yes', 'true', 't', 'y', '1'):
+    if msg.lower() in ("yes", "true", "t", "y", "1"):
         return True
-    elif msg.lower() in ('no', 'false', 'f', 'n', '0'):
+    elif msg.lower() in ("no", "false", "f", "n", "0"):
         return False
     else:
-        raise argparse.ArgumentTypeError(
-            'Boolean value expected. Got: {}'.format(msg))
+        raise argparse.ArgumentTypeError("Boolean value expected. Got: {}".format(msg))
+
 
 ##############################################################################
 # Book conversion formatting
 
 
-ALLOWED_CHARACTERS = string.ascii_letters + '-_/.' + string.digits
+ALLOWED_CHARACTERS = string.ascii_letters + "-_/." + string.digits
 
 
 def _split_yaml(lines):
@@ -54,41 +58,49 @@ def _split_yaml(lines):
     for ii, iline in enumerate(lines):
         iline = iline.strip()
         if yaml0 is None:
-            if iline == '---':
+            if iline == "---":
                 yaml0 = ii
             elif iline:
                 break
-        elif iline == '---':
-            return lines[yaml0 + 1:ii], lines[ii + 1:]
+        elif iline == "---":
+            return lines[yaml0 + 1 : ii], lines[ii + 1 :]
     return [], lines
 
 
 def _check_url_page(url_page, content_folder_name):
     """Check that the page URL matches certain conditions."""
     if not all(ii in ALLOWED_CHARACTERS for ii in url_page):
+        raise ValueError("Found unsupported character in filename: {}".format(url_page))
+    if "." in os.path.splitext(url_page)[-1]:
+        raise _error(
+            "A toc.yml entry links to a file directly. You should strip the file suffix.\n"
+            "Please change {} to {}".format(url_page, os.path.splitext(url_page)[0])
+        )
+    if any(
+        url_page.startswith(ii)
+        for ii in [content_folder_name, os.sep + content_folder_name]
+    ):
         raise ValueError(
-            "Found unsupported character in filename: {}".format(url_page))
-    if '.' in os.path.splitext(url_page)[-1]:
-        raise _error("A toc.yml entry links to a file directly. You should strip the file suffix.\n"
-                     "Please change {} to {}".format(url_page, os.path.splitext(url_page)[0]))
-    if any(url_page.startswith(ii) for ii in [content_folder_name, os.sep + content_folder_name]):
-        raise ValueError("It looks like you have a page URL that starts with your content folder's name."
-                         "page URLs should be *relative* to the content folder. Here is the page URL: {}".format(url_page))
+            "It looks like you have a page URL that starts with your content folder's name."
+            "page URLs should be *relative* to the content folder. Here is the page URL: {}".format(
+                url_page
+            )
+        )
 
 
 def _prepare_toc(toc):
     """Prepare the TOC for processing."""
     # Drop toc items w/o links
-    toc = [ii for ii in toc if ii.get('url', None) is not None]
+    toc = [ii for ii in toc if ii.get("url", None) is not None]
     # Un-nest the TOC so it's a flat list
     new_toc = []
     for ii in toc:
-        sections = ii.pop('sections', None)
+        sections = ii.pop("sections", None)
         new_toc.append(ii)
         if sections is None:
             continue
         for jj in sections:
-            subsections = jj.pop('subsections', None)
+            subsections = jj.pop("subsections", None)
             new_toc.append(jj)
             if subsections is None:
                 continue
@@ -100,15 +112,15 @@ def _prepare_toc(toc):
 def _prepare_url(url):
     """Prep the formatting for a url."""
     # Strip suffixes and prefixes of the URL
-    if not url.startswith('/'):
-        url = '/' + url
+    if not url.startswith("/"):
+        url = "/" + url
 
     # Standardize the quotes character
     url = url.replace('"', "'")
 
     # Make sure it ends in "HTML"
-    if not url.endswith('.html'):
-        url = op.splitext(url)[0] + '.html'
+    if not url.endswith(".html"):
+        url = op.splitext(url)[0] + ".html"
     return url
 
 
@@ -117,14 +129,45 @@ def _clean_markdown_cells(ntbk):
     # Remove '#' from the end of markdown headers
     for cell in ntbk.cells:
         if cell.cell_type == "markdown":
-            cell_lines = cell.source.split('\n')
+            cell_lines = cell.source.split("\n")
             for ii, line in enumerate(cell_lines):
-                if line.startswith('#'):
-                    cell_lines[ii] = line.rstrip('#').rstrip()
-            cell.source = '\n'.join(cell_lines)
+                if line.startswith("#"):
+                    cell_lines[ii] = line.rstrip("#").rstrip()
+            cell.source = "\n".join(cell_lines)
     return ntbk
 
 
 def _file_newer_than(path1, path2):
     """Check whether file at path1 is newer than path2."""
     return os.stat(path1).st_mtime > os.stat(path2).st_mtime
+
+
+def _check_book_versions(path_book):
+    """Check whether the version of a book matches the version of the
+    CLI that's building it."""
+
+    yaml = YAML()
+    config_version = yaml.load(op.join(path_book, "_config.yml")).get(
+        "jupyter_book_version"
+    )
+
+    if config_version is None:
+        raise _error(
+            "Couldn't find the version for your Jupyter Book.\n"
+            f"Try upgrading it with `jupyter-book upgrade {path_book}"
+        )
+
+    if config_version != __version__:
+        raise _error(
+            f"The version of the book you are modifying doesn't match the\n"
+            "version of the command-line tool that you're using. Please run\n"
+            "\n"
+            "    jupyter-book upgrade {path_book} \n"
+            "\n"
+            "to upgrade your book to the CLI version.\n"
+            "\n"
+            f"This book's version: {config_version}\n"
+            f"Your CLI's version: {__version__}"
+        )
+
+    return True

--- a/jupyter_book/utils.py
+++ b/jupyter_book/utils.py
@@ -63,7 +63,7 @@ def _split_yaml(lines):
             elif iline:
                 break
         elif iline == "---":
-            return lines[yaml0 + 1 : ii], lines[ii + 1 :]
+            return lines[yaml0 + 1: ii], lines[ii + 1:]
     return [], lines
 
 


### PR DESCRIPTION
This does a couple things around Jupyter Book versions and making it easier to figure out what is going wrong with a version conflict. Currently we're getting a decent number of errors because people upgrade jupyter book then run it on an older version of JB. This tries to get around that w/ the following changes:

* The version of JB is now encoded in the `_config.yml` file of the template repository (to make sure it always matches the latest JB CLI version).
* There's now a utility function that checks whether a book's version is the same as the CLI version and, if different, will instruct the person to run the upgrade command.

I'm curious if folks think it could be a problem to raise an error when there's a mismatch between the CLI and the book that it's trying to operate on. @emdupre do you have any thoughts on that?