### PR TITLE
removing _build artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,10 +80,6 @@ jobs:
           path: jupyter_book/book_template/_site/
           destination: html
 
-      - store_artifacts:
-          path: jupyter_book/book_template/_build/
-          destination: _build
-
   # Deploy the built site to jupyter-book.github.io
   deploy:
     docker:


### PR DESCRIPTION
Removing the _build artifacts in circleci, this takes quite a long time and we rarely use it, so if we want to see the build artifacts we can probably just preview locally