### PR TITLE
Update required python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     version=__version__,
     install_requires=install_packages,
     include_package_data=True,
-    python_requires='>=3.4',
+    python_requires='>=3.6',
     author='Project Jupyter Contributors',
     author_email='jupyter@googlegroups.com',
     url='https://jupyter.org/jupyter-book/',


### PR DESCRIPTION
Closes https://github.com/jupyter/jupyter-book/issues/355.

 - Updates required python version from 3.4 to 3.6