### PR TITLE
[fix] update docker image and documentation

### DIFF
--- a/jupyter_book/Dockerfile
+++ b/jupyter_book/Dockerfile
@@ -2,4 +2,4 @@ FROM jekyll/jekyll:3.8.5
 COPY book_template/Gemfile .
 RUN apk --update add make gcc g++ libc-dev
 RUN gem install bundler
-RUN bundle install
+ENTRYPOINT bundle install && bundle exec jekyll serve --host 0.0.0.0

--- a/jupyter_book/book_template/content/guide/04_publish.md
+++ b/jupyter_book/book_template/content/guide/04_publish.md
@@ -214,7 +214,7 @@ docker run --rm --security-opt label:disable  \
    -v /full/path/to/your/book:/srv/jekyll \
    -p 4000:4000 \
    -it -u 1000:1000 \
-   emdupre/jupyter-book bundle exec jekyll serve --host 0.0.0.0
+   emdupre/jupyter-book
 ```
 
 If you navigate to `http://0.0.0.0:4000/jupyter-book/` in your browser,
@@ -245,7 +245,7 @@ Make sure to specify the full path to your Jupyter Book, rather than the relativ
 ```bash
 singularity run -B /full/path/to/your/book:/srv/jekyll \
     --pwd /srv/jekyll \
-    jupyter-book.simg bundle exec jekyll serve
+    jupyter-book.simg
 ```
 
 And that's it! If you navigate to `http://127.0.0.1:4000/jupyter-book/` in your browser,


### PR DESCRIPTION
Closes #360.

- Updates the docker image to match the new image on dockerhub. 
- Updates relevant documentation describing how to use the image.