### PR TITLE
adding CSS rules for epigraphs

### DIFF
--- a/jupyter_book/book_template/_sass/page/components/_components.page.scss
+++ b/jupyter_book/book_template/_sass/page/components/_components.page.scss
@@ -135,16 +135,6 @@ pre.highlight code {
   display: block;
 }
 
-blockquote {
-  margin: $spacing-unit-small;
-  padding: $spacing-unit-med;
-  border-left: 4px solid $color-dark-gray;
-
-  p:last-child {
-    margin-bottom: 0;
-  }
-}
-
 /* Outputs */
 .output_stream,
 .output_data_text,
@@ -226,4 +216,49 @@ div.output_subarea {
 
 .jp-OutputPrompt {
   display: none;
+}
+
+// Quotation cells
+
+// Default
+blockquote {
+  margin: $spacing-unit-small;
+  border-left: 4px solid $color-dark-gray;
+  padding: $spacing-unit-tiny $spacing-unit-med;
+
+  p {
+    margin-bottom: $spacing-unit-small;
+  }
+
+  ul, ol {
+    margin-bottom: $spacing-unit-tiny;
+  }
+
+  // This should only trigger if the last child of a blockquote is an ul/ol
+  > :last-child li {
+    text-align: right;
+    list-style-type: none;
+    margin: none;
+    padding-right: 5%;
+
+    &:before {
+      content: "—";
+      padding-right: 10px;
+    }
+  }
+}
+
+// Epigraph adds new styling
+div.jb_cell.tag_epigraph blockquote {
+
+  font-style: italic;
+  font-size: 1.2em;
+  width: 90%;
+  margin-left: auto;
+  margin-right: auto;
+  border-left: none;
+
+  ul {
+    font-style: normal;
+  }
 }

--- a/jupyter_book/book_template/content/features/layout.ipynb
+++ b/jupyter_book/book_template/content/features/layout.ipynb
@@ -186,6 +186,65 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Quotations\n",
+    "\n",
+    "There are two types of quotations in Jupyter Book: **blockquotes**\n",
+    "and **epigraphs**.\n",
+    "\n",
+    "**Blockquotes** are useful for calling out some information provided\n",
+    "by another source. They don't break much with the content of the\n",
+    "page.\n",
+    "\n",
+    "> Here's an example of a blockquote. It is triggered by using the\n",
+    "> \"caret\" (`>`) symbol at the beginning of each line that you'd\n",
+    "> like to add a blockquote for. If you finish the quote with a\n",
+    "> `-` symbol, it will be treated as an \"attribution\" line and\n",
+    "> will be right-aligned.\n",
+    ">\n",
+    "> - Jo the Jovyan"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "epigraph"
+    ]
+   },
+   "source": [
+    "**Epigraphs** are useful for introducing a particular page or idea.\n",
+    "They're inspired by [Edward Tufte's epigraph CSS](https://edwardtufte.github.io/tufte-css/#epigraphs).\n",
+    "Epigraphs have a bit more emphasis and also differ in style a bit more from\n",
+    "your page's content in order to draw attention to them.\n",
+    "\n",
+    "> Here's an example of an epigraph quote. Note that in this case,\n",
+    "> the quote itself is a bit larger and italicized. You probably\n",
+    "> shouldn't make this *too* long so that they don't stand out\n",
+    "> too much.\n",
+    ">\n",
+    "> - Jo the Jovyan"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To indicate that you'd like an *epigraph* instead of a *blockquote*, add\n",
+    "the following tag your cell's tag list:\n",
+    "    \n",
+    "```json\n",
+    "{\n",
+    "    \"tags\": [\n",
+    "        \"epigraph\",\n",
+    "    ]\n",
+    "}\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Wide-format cells\n",
     "\n",
     "Sometimes, you'd like to use **all** of the horizontal space available to you. This allows\n",


### PR DESCRIPTION
This adds a set of CSS rules for the "epigraph" tag, allowing people to add more fancy-style quotes to their pages. Here's the section that describes it:

https://5d91217509272c00083e9ba8--jupyter-book.netlify.com/features/layout.html#Quotations

Here's the new epigraph style (triggered with a tag):

![image](https://user-images.githubusercontent.com/1839645/65839602-6d31ef80-e2c3-11e9-84a5-1353812d392e.png)

and here's a slightly updated blockquote style (the default):

![image](https://user-images.githubusercontent.com/1839645/65839607-7753ee00-e2c3-11e9-8901-6ce08e7068c3.png)

This was partially inspired by @stefanv and @jni 's "elegant scipy" book :-)