### PR TITLE
adding anchors above headers

### DIFF
--- a/jupyter_book/book_template/_sass/page/components/_components.page.scss
+++ b/jupyter_book/book_template/_sass/page/components/_components.page.scss
@@ -26,6 +26,18 @@ div.jb_cell {
   @include mq($from: laptop) {
     width: $textbook-page-with-sidebar-width;
   }
+
+  // Add some empty space before headers for anchor links
+  h1, h2, h3, h4, h5 {
+    &:before {
+      display: block;
+      content: " ";
+      margin-top: -80px;
+      height: 80px;
+      visibility: hidden;
+      pointer-events: none;
+    }
+  }
 }
 
 #page-title {


### PR DESCRIPTION
This adds an empty pseudo-element before all h2/h3/h4/h5 headers. It doesn't change the display at all but it should make it so that anchor links will snap to a vertical scroll where the headers are still visible.

For example, clicking this should center the header just under the topbar:

https://deploy-preview-366--jupyter-book.netlify.com/guide/04_publish.html#When-should-you-build-the-HTML-locally?