### PR TITLE
fixing interact link bug

### DIFF
--- a/jupyter_book/build.py
+++ b/jupyter_book/build.py
@@ -274,10 +274,11 @@ def build_book(path_book, path_toc_yaml=None, path_ssg_config=None,
             yaml_fm += ['redirect_from:']
             yaml_fm += ['  - "{}"'.format(sanitized)]
 
-        # Add interactive kernel info
-        yaml_fm += ['interact_link: {}'.format(path_page_rel_content_folder.replace(os.sep, '/'))]
-        yaml_fm += ["kernel_name: {}".format(kernel_name)]
-        yaml_fm += ["has_widgets: {}".format(has_widgets)]
+        # Add interactive kernel info if the page is executable
+        if chosen_suff == ".ipynb":
+            yaml_fm += ['interact_link: {}'.format(path_page_rel_content_folder.replace(os.sep, '/'))]
+            yaml_fm += ["kernel_name: {}".format(kernel_name)]
+            yaml_fm += ["has_widgets: {}".format(has_widgets)]
 
         # Page metadata
         # Use YAML block scalars for titles so that people can use special characters

--- a/jupyter_book/tests/test_create.py
+++ b/jupyter_book/tests/test_create.py
@@ -248,6 +248,9 @@ def test_notebook(tmpdir):
     # No interactive outputs
     assert is_in(lines, "has_widgets: false")
 
+    # Interact links are there
+    assert is_in(lines, "interact_link:")
+
     # Testing external link being excluded from "next page"
     assert not is_in(lines, "url: https://github.com")
 
@@ -267,6 +270,14 @@ def test_notebook(tmpdir):
     with open(op.join(path_build_test, '_build', 'simple_notebook.html'), 'r') as ff:
         lines = ff.readlines()
     assert is_in(lines, '<img src="images/simple_notebook_2_0.png"')
+
+    ###########################################
+    # Testing markdown file conversion
+
+    with open(op.join(path_build_test, '_build', 'tests', 'markdown.html'), 'r') as ff:
+        lines = ff.readlines()
+
+    assert not is_in(lines, 'interact_link: ')
 
 
 def test_extra_yaml(tmpdir):


### PR DESCRIPTION
This fixes a bug where interact links were placed for *all* pages, not just notebooks, because we're reading them in with jupytext now. This fixes things so they only show up for notebooks now. We might want to change that in the future but that's for another day