### PR TITLE
moving to jupyterbook.org

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,6 @@ jobs:
           name: Build site intermediate files
           command: jupyter-book build jupyter_book/book_template/
 
-
       # Persist the built files for the deploy step
       - persist_to_workspace:
           root: .
@@ -82,28 +81,6 @@ jobs:
           name: Build the website
           command: cd jupyter_book/book_template && bundle exec jekyll build --baseurl /0/html/
 
-  # Deploy the built site to jupyter-book.github.io
-  deploy:
-    docker:
-      - image: circleci/python:3.7-stretch
-    steps:
-      # Add deployment key fingerprint for CircleCI to use for a push
-      - add_ssh_keys:
-          fingerprints:
-            - "19:34:f0:15:b8:3a:e4:44:27:a8:e9:8b:b5:e4:48:a9"
-
-      - prepare_jekyll_installation
-      - run:
-          name: Build the website for deploy
-          command: cd jupyter_book/book_template && bundle exec jekyll build
-
-      # Deploy the built site with ghp-import
-      - run:
-          name: Deploying site using ghp-import
-          command: |
-            pip install ghp-import
-            ghp-import -p -f -n ./jupyter_book/book_template/_site/
-
 
 # Tell CircleCI to use this workflow when it builds the site
 workflows:
@@ -122,15 +99,6 @@ workflows:
             branches:
               ignore:
                 - gh-pages
-      - deploy:
-          requires:
-            - run_tests
-          filters:
-              branches:
-                only:
-                  - master
-                ignore:
-                  - gh-pages
 
 commands:
   prepare_jekyll_installation:

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ content with your own, and have a Jupyter-based textbook ready to go shortly!
 
 Here are a few links of interest:
 
-* **[A demo of the hosted textbook](http://jupyter.org/jupyter-book/ )**
-* **[A short guide to deploying your own textbook](https://jupyter.org/jupyter-book/guide/01_overview)**
+* **[A demo of the hosted textbook](https://jupyterbook.org/ )**
+* **[A short guide to deploying your own textbook](https://jupyterbook.org/guide/01_overview)**
 * **[The markdown version of the guide in this repo](jupyter_book/book_template/content/guide/)**
 
 ## Explore this book

--- a/jupyter_book/book_template/.circleci/config.yml
+++ b/jupyter_book/book_template/.circleci/config.yml
@@ -1,7 +1,7 @@
 # NOTE: This is an example CircleCI configuration that
 # will build your book and preview its HTML content.
 # You will probably have to modify it in order to get it working
-# just the way you want. See https://jupyter.org/jupyter-book/advanced/circleci.html
+# just the way you want. See https://jupyterbook.org/advanced/circleci.html
 # for more information
 version: 2.1
 

--- a/jupyter_book/book_template/_config.yml
+++ b/jupyter_book/book_template/_config.yml
@@ -22,8 +22,8 @@ email: choldgraf@berkeley.edu
 description: >- # this means to ignore newlines until "baseurl:"
   This is an example book built with Jupyter Books.
 
-baseurl: "/jupyter-book" # the subpath of your site, e.g. /blog. If there is no subpath for your site, use an empty string ""
-url: "https://jupyter.org" # the base hostname & protocol for your site, e.g. http://example.com
+baseurl: "" # the subpath of your site, e.g. /blog. If there is no subpath for your site, use an empty string ""
+url: "https://jupyterbook.org" # the base hostname & protocol for your site, e.g. http://example.com
 
 
 #######################################################################################
@@ -36,8 +36,8 @@ footer_text               : This page was created by <a href="https://github.com
 show_sidebar              : true  # Show the sidebar. Only set to false if your only wish to host a single page.
 collapse_inactive_chapters: true  # Whether to collapse the inactive chapters in the sidebar
 textbook_logo             : images/logo/logo.png  # A logo to be displayed at the top of your textbook sidebar. Should be square
-textbook_logo_link        : https://jupyter.org/jupyter-book/intro.html  # A link for the logo.
-sidebar_footer_text       : 'Powered by <a href="https://github.com/jupyter/jupyter-book">Jupyter Book</a>'
+textbook_logo_link        : https://jupyterbook.org/intro.html  # A link for the logo.
+sidebar_footer_text       : 'Powered by <a href="https://jupyterbook.org">Jupyter Book</a>'
 number_toc_chapters       : true  # Whether to add numbers to chapterse in your Table of Contents. If true, you can control this at the Chapter level in _data/toc.yml
 
 # Search settings

--- a/jupyter_book/book_template/content/advanced/circleci.ipynb
+++ b/jupyter_book/book_template/content/advanced/circleci.ipynb
@@ -390,7 +390,7 @@
     "# NOTE: This is an example CircleCI configuration that\n",
     "# will build your book and preview its HTML content.\n",
     "# You will probably have to modify it in order to get it working\n",
-    "# just the way you want. See https://jupyter.org/jupyter-book/advanced/circleci.html\n",
+    "# just the way you want. See https://jupyterbook.org/advanced/circleci.html\n",
     "# for more information\n",
     "version: 2.1\n",
     "jobs:\n",

--- a/jupyter_book/book_template/content/advanced/netlify.md
+++ b/jupyter_book/book_template/content/advanced/netlify.md
@@ -22,7 +22,7 @@ Although Netlify has both free and paid tiers, the build process is the same acr
 Importantly, the free tier only allows for 100GB of bandwidth usage per month across all of your Netlify built projects.
 
 If your Jupyter Book will be used by a large audience, or if you're creating many Jupyter Books, you might want to consider registering for [a paid account](https://www.netlify.com/pricing/).
-You can also instead automatically build your Jupyter Book with CircleCI, using the configuration shown in the section on [Automatically building, previewing, and pushing your book with CircleCI](https://jupyter.org/jupyter-book/advanced/circleci.html).
+You can also instead automatically build your Jupyter Book with CircleCI, using the configuration shown in the section on [Automatically building, previewing, and pushing your book with CircleCI](https://jupyterbook.org/advanced/circleci.html).
 
 In order to use Netlify, you'll need to [create an account](https://app.netlify.com/signup).
 Here, we'll walk through connecting your Jupyter Book to Netlify's continous deployment services using their UI.

--- a/jupyter_book/book_template/content/features/limits.md
+++ b/jupyter_book/book_template/content/features/limits.md
@@ -468,7 +468,7 @@ docker run --rm --security-opt label:disable  \
 If you navigate to `http://0.0.0.0:4000/jupyter-book/` in your browser,
 you should see a preview copy of your book.
 If you instead see an error, please try to update your local book;
-see [the Jupyter Book FAQ section](https://jupyter.org/jupyter-book/guide/04_faq.html#how-can-i-update-my-book)
+see [the Jupyter Book FAQ section](https://jupyterbook.org/guide/04_faq.html#how-can-i-update-my-book)
 for more details on how to do so.
 
 ### Building your site locally with Containers: Singularity

--- a/jupyter_book/book_template/content/guide/02_create.md
+++ b/jupyter_book/book_template/content/guide/02_create.md
@@ -29,7 +29,7 @@ jupyter-book toc mybookname/
 ## by modifying the Demo Book
 
 If you'd like to see a more fully-functioning demo book for inspiration, you can
-create the book that lives at the [jupyter-book website](https://jupyter.org/jupyter-book)
+create the book that lives at the [jupyter-book website](https://jupyterbook.org)
 by adding the `--demo` flag:
 
 ```

--- a/jupyter_book/book_template/content/guide/04_publish.md
+++ b/jupyter_book/book_template/content/guide/04_publish.md
@@ -220,7 +220,7 @@ docker run --rm --security-opt label:disable  \
 If you navigate to `http://0.0.0.0:4000/jupyter-book/` in your browser,
 you should see a preview copy of your book.
 If you instead see an error, please try to update your local book;
-see [the Jupyter Book FAQ section](https://jupyter.org/jupyter-book/guide/04_faq.html#how-can-i-update-my-book)
+see [the Jupyter Book FAQ section](https://jupyterbook.org/guide/04_faq.html#how-can-i-update-my-book)
 for more details on how to do so.
 
 You'll find the HTML for your book in the `_site/` folder.
@@ -257,7 +257,7 @@ If you're choosing to build the HTML for your book by hand, there are a few opti
 where you should store the book. The two most common approaches are:
 
 * **Use the `gh-pages` or `master` branch of a GitHub repository**. In this case, the build
-  process is very similar to [using GH-pages to build the HTML for your site](https://jupyter.org/jupyter-book/guide/03_build.html#publish-your-book-online-with-github-pages).
+  process is very similar to [using GH-pages to build the HTML for your site](https://jupyterbook.org/guide/03_build.html#publish-your-book-online-with-github-pages).
   However, there is one caveat: you must include a file called `.nojekyll` along with the HTML
   files of your book. This tells GitHub **not** to use Jekyll to build the HTML.
 * **Use a static site hosting service like Netlify**. There are many services that will simply

--- a/jupyter_book/create.py
+++ b/jupyter_book/create.py
@@ -139,7 +139,7 @@ def new_book(path_out, content_folder, toc,
         message = [
             "- You've chosen to copy over the demo Jupyter Book. This"
             "  contains",
-            "  the content shown at https://jupyter.org/jupyter-book.\n"
+            "  the content shown at https://jupyterbook.org.\n"
             "  Use it to get acquainted with the Jupyter-Book structure"
             " and build ",
             "  system. When you're ready, try re-running"

--- a/jupyter_book/minimal/_config.yml
+++ b/jupyter_book/minimal/_config.yml
@@ -7,7 +7,7 @@ email: YOUR EMAIL
 baseurl: "/" # the subpath of your site, e.g. /blog. If there is no subpath for your site, use an empty string ""
 url: "YOUR URL" # the base hostname & protocol for your site, e.g. http://example.com
 
-textbook_logo_link        : https://jupyter.org/jupyter-book/  # A link for the logo.
+textbook_logo_link        : https://jupyterbook.org/  # A link for the logo.
 
 #######################################################################################
 # Interact link settings

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "gem install bundler -v '2.0.2' && pip install -U git+https://github.com/jupyter/jupyter-book && jupyter-book build ./ --overwrite && bundle exec jekyll build --baseurl ''"
+  command = "gem install bundler -v '2.0.2' && pip install -U git+https://github.com/jupyter/jupyter-book && jupyter-book build ./ --overwrite && bundle exec jekyll build"
 
 [context.deploy-preview]
-  command = "gem install bundler -v '2.0.2' && pip install -e ../../ && jupyter-book build ./ --overwrite && bundle exec jekyll build --baseurl ''"
+  command = "gem install bundler -v '2.0.2' && pip install -e ../../ && jupyter-book build ./ --overwrite && bundle exec jekyll build"

--- a/setup.py
+++ b/setup.py
@@ -27,9 +27,9 @@ setup(
     python_requires='>=3.6',
     author='Project Jupyter Contributors',
     author_email='jupyter@googlegroups.com',
-    url='https://jupyter.org/jupyter-book/',
+    url='https://jupyterbook.org/',
     project_urls={
-        'Documentation': 'https://jupyter.org/jupyter-book',
+        'Documentation': 'https://jupyterbook.org',
         'Funding': 'https://jupyter.org/about',
         'Source': 'https://github.com/jupyter/jupyter-book/',
         'Tracker': 'https://github.com/jupyter/jupyter-book/issues',


### PR DESCRIPTION
This sets up book configuration and changes links to point to jupyterbook.org

closes #370 

we'll need to set up redirects for the `jupyter.org/jupyter-book` pages as well