### PR TITLE
removing unnecessary requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,9 @@ ruamel.yaml
 pyyaml
 libsass
 tqdm
-numpy
-nbformat
 setuptools
-jupyter_contrib_nbextensions
 jupytext
+nbformat
+nbconvert
+jupyter_client
+ipykernel


### PR DESCRIPTION
This is mostly because `jupyter_contrib_nbextensions` is a pretty big dependency