### PR TITLE
moving CSS and JS generation to their own function

### DIFF
--- a/jupyter_book/commands/page.py
+++ b/jupyter_book/commands/page.py
@@ -23,7 +23,8 @@ def page():
     parser.add_argument("--path_media_output", default=None,
                         help="The path to where images should be extracted")
     parser.add_argument("--execute", action='store_true', help="Execute the notebook before converting")
-    parser.set_defaults(execute=False)
+    parser.add_argument("--no-head", action='store_true', help="Do not add a <head> to the output page HTML")
+    parser.set_defaults(execute=False, no_head=False)
 
     ###############################################
     # Default values and arguments
@@ -68,6 +69,7 @@ def page():
     )
 
     # Write to disk as a standalone HTML page
-    path_html = write_page(html, PATH_HTML_OUTPUT, resources, standalone=True,
+    standalone = not args.no_head
+    path_html = write_page(html, PATH_HTML_OUTPUT, resources, standalone=standalone,
                            custom_css=custom_css, custom_js=custom_js)
     print(f"HTML created at: {path_html}")

--- a/jupyter_book/page/page.py
+++ b/jupyter_book/page/page.py
@@ -18,7 +18,7 @@ PATH_MATHJAX = op.join(PATH_BOOK_TEMPLATE, "_includes", "mathjax.html")
 PATH_JS = op.join(PATH_BOOK_TEMPLATE, "assets", "js", "page")
 PATH_SCSS = op.join(PATH_BOOK_TEMPLATE, "_sass", "page", "main.scss")
 
-PAGE_CSS = """
+PAGE_EXTRA_CSS = """
 <style type="text/css">
 main.jupyter-page {
     max-width: 1100px;
@@ -232,25 +232,12 @@ def page_head(custom_css='', custom_js=''):
 
     This uses CSS/JS from the book template.
     """
-    # Javascript files to embed
-    js_files = [
-        "dom-update.js",
-        "documentSelectors.js",
-        "copy-button.js",
-        "hide-cell.js",
-        "anchors.js",
-        "tocbot.js"
-    ]
-
-    js = []
-    for js_file in js_files:
-        with open(op.join(PATH_JS, js_file), "r") as ff:
-            js += ["<script>"]
-            js += ff.readlines()
-            js += ["</script>"]
-
-    js = "\n".join(js)
-
+    js = page_js()
+    js = f"""
+        <script>
+        {js}
+        </script>
+        """
     if custom_js:
         custom_js = f"""
             <script>
@@ -263,7 +250,7 @@ def page_head(custom_css='', custom_js=''):
         html_mathjax = ff.read()
 
     # SCSS styling for the page
-    scss = sass.compile(filename=PATH_SCSS)
+    scss = page_css()
     scss = f"""
     <style type="text/css">
     {scss}
@@ -285,9 +272,36 @@ def page_head(custom_css='', custom_js=''):
     {html_mathjax}
     {scss}
     {custom_css}
-    {PAGE_CSS}
+    {PAGE_EXTRA_CSS}
     {js}
     {custom_js}
     </head>
     """
     return head
+
+
+def page_css():
+    """Return a page's CSS."""
+    css = sass.compile(filename=PATH_SCSS)
+    return css
+
+
+def page_js():
+    """Return a page's javascript."""
+    # Javascript files to embed
+    js_files = [
+        "dom-update.js",
+        "documentSelectors.js",
+        "copy-button.js",
+        "hide-cell.js",
+        "anchors.js",
+        "tocbot.js"
+    ]
+
+    js = []
+    for js_file in js_files:
+        with open(op.join(PATH_JS, js_file), "r") as ff:
+            js += ff.readlines()
+
+    js = "\n".join(js)
+    return js


### PR DESCRIPTION
This moves out the single-page CSS and JS bits to a function that returns the CSS/JS content. The goal is to make it easier for folks to return the CSS or JS if they want to do so without embedding it in a page's HTML.