### PR TITLE
[FIX] Fix for path separator issue on Windows

### DIFF
--- a/jupyter_book/build.py
+++ b/jupyter_book/build.py
@@ -139,7 +139,7 @@ def build_book(path_book, path_toc_yaml=None, path_ssg_config=None,
         # URL will be relative to the CONTENT_FOLDER
         path_url_page = os.path.join(PATH_CONTENT_FOLDER, url_page.lstrip('/'))
         path_url_folder = os.path.dirname(path_url_page)
-        notebook_name = path_url_page.split(os.sep)[-1]  # No extension yet
+        notebook_name = op.split(path_url_page)[-1]  # No extension yet
 
         # URLs shouldn't have the suffix in there already so
         # now we find which one to add

--- a/jupyter_book/page/page.py
+++ b/jupyter_book/page/page.py
@@ -1,6 +1,5 @@
 """Single page HTML building / writing functionality."""
 import os.path as op
-import os
 from traitlets.config import Config
 
 from nbconvert.exporters import HTMLExporter

--- a/jupyter_book/page/page.py
+++ b/jupyter_book/page/page.py
@@ -87,7 +87,7 @@ def write_page(html, path_out, resources, standalone=False,
     """
     c = Config()
     c.FilesWriter.build_directory = path_out
-    notebook_name = resources.get("unique_key", "notebook").split(os.sep)[-1]
+    notebook_name = op.split(resources.get("unique_key", "notebook"))[-1]
 
     if custom_css is None:
         custom_css = ''

--- a/jupyter_book/toc.py
+++ b/jupyter_book/toc.py
@@ -110,7 +110,7 @@ def build_toc(content_folder, filename_split_char='_'):
                     toc_pages.append({'title': i_title, 'url': i_url})
         else:
             # Grab the top-most folder to choose which list we'll append to
-            folder = path_rel_to_content.lstrip('/').split(os.sep)[0]
+            folder = op.split(path_rel_to_content.lstrip('/'))[0]
 
             # If the file ends in ipynb or md, add it to this section
             for ifile in ifiles:

--- a/jupyter_book/toc.py
+++ b/jupyter_book/toc.py
@@ -110,7 +110,7 @@ def build_toc(content_folder, filename_split_char='_'):
                     toc_pages.append({'title': i_title, 'url': i_url})
         else:
             # Grab the top-most folder to choose which list we'll append to
-            folder = op.split(path_rel_to_content.lstrip('/'))[0]
+            folder = path_rel_to_content.lstrip('/').split(os.sep)[0]
 
             # If the file ends in ipynb or md, add it to this section
             for ifile in ifiles:


### PR DESCRIPTION
Closes #397 

Switched to using `os.path.split` instead of `str.split(os.sep)` when working with paths from `toc.yml`, that caused problem building on Windows.