### PR TITLE
moving some modules to pathlib

### DIFF
--- a/jupyter_book/__init__.py
+++ b/jupyter_book/__init__.py
@@ -1,13 +1,13 @@
 """Build an online book using Jupyter Notebooks and Jekyll."""
-import os.path as op
+from pathlib import Path
 import os
 
 # Load the version from the template Jupyter Book repository config
-path_yml = op.join(op.dirname(__file__), 'book_template', '_config.yml')
-with open(path_yml, 'r') as ff:
-    # Read in the version *without* pyyaml because we can't assume it's installed
-    lines = ff.readlines()
+path_file = Path(__file__)
+path_yml = path_file.parent.joinpath('book_template', '_config.yml')
 
+# Read in the version *without* pyyaml because we can't assume it's installed
+lines = path_yml.read_text().split('\n')
 version = [line for line in lines if 'jupyter_book_version' in line]
 version_line = [line for line in lines if 'jupyter_book_version' in line][0]
 __version__ = version_line.split(' ')[-1].strip().strip('"')

--- a/jupyter_book/book_template/scripts/clean.py
+++ b/jupyter_book/book_template/scripts/clean.py
@@ -1,13 +1,13 @@
 """A helper script to "clean up" all of your generated markdown and HTML files."""
 import shutil as sh
-import os.path as op
+from pathlib import Path
 
-path_root = op.join(op.dirname(op.abspath(__file__)), '..')
+path_root = Path(__file__).parent.parent
 
-paths = [op.join(path_root, '_site'),
-         op.join(path_root, '_build')]
+paths = [path_root.joinpath('_site'),
+         path_root.joinpath('_build')]
 for path in paths:
-    print('Removing {}...'.format(path))
+    print(f'Removing {path}...')
     sh.rmtree(path, ignore_errors=True)
 
 print('Done!')

--- a/jupyter_book/build.py
+++ b/jupyter_book/build.py
@@ -12,7 +12,6 @@ from .utils import (print_message_box, _check_url_page, load_ntbk,
                     _prepare_url, _error, _file_newer_than, _check_book_versions,
                     _is_jupytext_file)
 from .page import page_html, write_page, _RawCellPreprocessor
-from .toc import _prepare_toc
 
 # Defaults
 BUILD_FOLDER_NAME = "_build"
@@ -36,6 +35,25 @@ def _copy_non_content_files(path_content_folder, content_folder_name,
         if not op.isdir(op.dirname(new_path)):
             os.makedirs(op.dirname(new_path))
         sh.copy2(ifile, new_path)
+
+
+def _prepare_toc(toc):
+    """Prepare the TOC for processing."""
+    # Un-nest the TOC so it's a flat list
+    new_toc = []
+    for chapter in toc:
+        sections = chapter.get('sections', [])
+        new_toc.append(chapter)
+        for section in sections:
+            subsections = section.get('subsections', [])
+            new_toc.append(section)
+            new_toc.extend(subsections)
+
+    # Omit items that don't have URLs (like dividers) or have an external link
+    return [
+        item for item in new_toc
+        if 'url' in item and not item.get('external', False)
+    ]
 
 
 def _case_sensitive_fs(path):


### PR DESCRIPTION
This moves a few of the smaller modules to Pathlib, to see how the code looks and make sure that things still work properly. It significantly cleaned up the `toc.py` module, which is pretty nice :-)