### PR TITLE
[FIX] Fix for on-page anchor-based TOC issues

### DIFF
--- a/jupyter_book/book_template/_includes/head.html
+++ b/jupyter_book/book_template/_includes/head.html
@@ -55,7 +55,7 @@
   {% include js/thebelab.html %}
 
   <!-- Load the auto-generating TOC (non-async otherwise the TOC won't load w/ turbolinks) -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/tocbot/4.4.2/tocbot.min.js" async></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/tocbot/4.8.1/tocbot.min.js" async></script>
   <script src="{{ site.js_url | relative_url }}/page/tocbot.js"></script>
 
   <!-- Google analytics -->

--- a/jupyter_book/book_template/assets/js/page/anchors.js
+++ b/jupyter_book/book_template/assets/js/page/anchors.js
@@ -6,7 +6,7 @@ const initAnchors = () => {
   anchors.add("main h1, main h2, main h3, main h4");
 
   // Disable Turbolinks for anchors
-  document.querySelector('.anchorjs-link')
+  document.querySelectorAll('.anchorjs-link')
     .forEach(it => it.dataset['turbolinks'] = false);
 }
 initFunction(initAnchors);

--- a/jupyter_book/book_template/assets/js/page/anchors.js
+++ b/jupyter_book/book_template/assets/js/page/anchors.js
@@ -7,6 +7,6 @@ const initAnchors = () => {
 
   // Disable Turbolinks for anchors
   document.querySelector('.anchorjs-link')
-  	.forEach(it => it.dataset['turbolinks'] = false);
+    .forEach(it => it.dataset['turbolinks'] = false);
 }
 initFunction(initAnchors);

--- a/jupyter_book/book_template/assets/js/page/anchors.js
+++ b/jupyter_book/book_template/assets/js/page/anchors.js
@@ -1,8 +1,12 @@
 const initAnchors = () => {
-    if (window.anchors === undefined) {
-      setTimeout(initAnchors, 250)
-      return
-    }
-    anchors.add("main h1, main h2, main h3, main h4")
+  if (window.anchors === undefined) {
+    setTimeout(initAnchors, 250);
+    return;
   }
+  anchors.add("main h1, main h2, main h3, main h4");
+
+  // Disable Turbolinks for anchors
+  document.querySelector('.anchorjs-link')
+  	.forEach(it => it.dataset['turbolinks'] = false);
+}
 initFunction(initAnchors);

--- a/jupyter_book/book_template/assets/js/page/tocbot.js
+++ b/jupyter_book/book_template/assets/js/page/tocbot.js
@@ -1,7 +1,7 @@
 const initToc = () => {
   if (window.tocbot === undefined) {
-    setTimeout(initToc, 250)
-    return
+    setTimeout(initToc, 250);
+    return;
   }
 
   // Check whether we have any sidebar content. If not, then show the sidebar earlier.
@@ -19,8 +19,12 @@ const initToc = () => {
     orderedList: false,
     collapseDepth: 6,
     listClass: 'toc__menu',
-    activeListItemClass: "",  // Not using
-    activeLinkClass: "", // Not using
+    activeListItemClass: " ",  // Not using, can't be empty
+    activeLinkClass: " ", // Not using, can't be empty
   });
+
+  // Disable Turbolinks for TOC links
+  document.querySelectorAll('.toc-list-item a')
+    .forEach(it => it.dataset['turbolinks'] = false);
 }
 initFunction(initToc);


### PR DESCRIPTION
Upgraded the vesion of `tocbot`.

Added a code to add `data-turbolinks="false"` to all `anchorjs` and `tocbot` dynamically generated links when they are generated. This should solve the issue with anchors/TOC wonky behaviour, especially when containing Unicode.

Changed `activeListItemClass` and `activeLinkClass` in `tocbot` options to be non-empty strings to fix the issue with mangled class names on generated links.

Closes #170