### PR TITLE
only show TOC if there are headers for it

### DIFF
--- a/jupyter_book/book_template/assets/js/page/tocbot.js
+++ b/jupyter_book/book_template/assets/js/page/tocbot.js
@@ -11,17 +11,25 @@ const initToc = () => {
     document.querySelector('nav.onthispage').classList.add('no_sidebar_content')
   }
 
-  // Initialize the TOC bot
-  tocbot.init({
-    tocSelector: 'nav.onthispage',
-    contentSelector: '.c-textbook__content',
-    headingSelector: 'h1, h2, h3',
-    orderedList: false,
-    collapseDepth: 6,
-    listClass: 'toc__menu',
-    activeListItemClass: " ",  // Not using, can't be empty
-    activeLinkClass: " ", // Not using, can't be empty
-  });
+  // Initialize the TOC bot if we have TOC headers
+  const tocContent = '.c-textbook__content';
+  const tocHeaders = 'h1, h2, h3';
+  var headers = document.querySelector(tocContent).querySelectorAll(tocHeaders);
+  if (headers.length > 0) {
+    document.querySelector('aside.sidebar__right').classList.remove('hidden');
+    tocbot.init({
+      tocSelector: 'nav.onthispage',
+      contentSelector: tocContent,
+      headingSelector: tocHeaders,
+      orderedList: false,
+      collapseDepth: 6,
+      listClass: 'toc__menu',
+      activeListItemClass: " ",  // Not using, can't be empty
+      activeLinkClass: " ", // Not using, can't be empty
+    });
+  } else {
+    document.querySelector('aside.sidebar__right').classList.add('hidden');
+  }
 
   // Disable Turbolinks for TOC links
   document.querySelectorAll('.toc-list-item a')


### PR DESCRIPTION
This will remove the `on this page` section for pages that do not have any headers in them. It addresses some of the points in #438 from @melaniewalsh - curious what she thinks about this!

Example of no "on this page": https://deploy-preview-441--jupyter-book.netlify.com/01/what-is-data-science.html