### PR TITLE
scrolling outputs

### DIFF
--- a/jupyter_book/book_template/_sass/page/components/_components.page.scss
+++ b/jupyter_book/book_template/_sass/page/components/_components.page.scss
@@ -103,6 +103,11 @@ div.jb_cell {
       max-width: 100%;
     }
   }
+    
+  &.tag_output_scroll div.output_wrapper {
+      max-height: 24em;
+      overflow-y: auto;
+  }
 }
 
 

--- a/jupyter_book/book_template/content/features/layout.ipynb
+++ b/jupyter_book/book_template/content/features/layout.ipynb
@@ -245,6 +245,92 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Scrolling cell outputs\n",
+    "\n",
+    "The traditional Jupyter Notebook interface allows you to toggle **output scrolling**\n",
+    "for your cells. This allows you to visualize part of a long output without it taking up\n",
+    "the entire page.\n",
+    "\n",
+    "You can trigger this behavior in Jupyter Book by adding the following\n",
+    "tag to a cell's metadata:\n",
+    "\n",
+    "\n",
+    "```json\n",
+    "{\n",
+    "    \"tags\": [\n",
+    "        \"output_scroll\",\n",
+    "    ]\n",
+    "}\n",
+    "```\n",
+    "\n",
+    "For example, the following cell has a long output, but will be scrollable in the book."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "tags": [
+     "output_scroll"
+    ]
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "this is output line 0\n",
+      "this is output line 1\n",
+      "this is output line 2\n",
+      "this is output line 3\n",
+      "this is output line 4\n",
+      "this is output line 5\n",
+      "this is output line 6\n",
+      "this is output line 7\n",
+      "this is output line 8\n",
+      "this is output line 9\n",
+      "this is output line 10\n",
+      "this is output line 11\n",
+      "this is output line 12\n",
+      "this is output line 13\n",
+      "this is output line 14\n",
+      "this is output line 15\n",
+      "this is output line 16\n",
+      "this is output line 17\n",
+      "this is output line 18\n",
+      "this is output line 19\n",
+      "this is output line 20\n",
+      "this is output line 21\n",
+      "this is output line 22\n",
+      "this is output line 23\n",
+      "this is output line 24\n",
+      "this is output line 25\n",
+      "this is output line 26\n",
+      "this is output line 27\n",
+      "this is output line 28\n",
+      "this is output line 29\n",
+      "this is output line 30\n",
+      "this is output line 31\n",
+      "this is output line 32\n",
+      "this is output line 33\n",
+      "this is output line 34\n",
+      "this is output line 35\n",
+      "this is output line 36\n",
+      "this is output line 37\n",
+      "this is output line 38\n",
+      "this is output line 39\n"
+     ]
+    }
+   ],
+   "source": [
+    "for ii in range(40):\n",
+    "    print(f\"this is output line {ii}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Wide-format cells\n",
     "\n",
     "Sometimes, you'd like to use **all** of the horizontal space available to you. This allows\n",


### PR DESCRIPTION
This adds CSS to handle "scrolling outputs". If the outputs are too long, then cells with this tag will have the output scrollable instead of taking up the full vertical space. This can be useful for outputs with lots of vertical space.

closes https://github.com/jupyter/jupyter-book/issues/443

apologies for taking over this one if you were planning to do it @melaniewalsh! I had an extra moment and figured I'd give it a shot