### PR TITLE
moving thebelab config to within the page instead of head

### DIFF
--- a/jupyter_book/book_template/_includes/js/thebelab-page-config.html
+++ b/jupyter_book/book_template/_includes/js/thebelab-page-config.html
@@ -1,0 +1,32 @@
+<script type="text/x-thebe-config">
+{%- if page.kernel_name %}
+    {% assign kernelName = page.kernel_name %}
+{% else %}
+    {% assign kernelName = "python3" %}
+{% endif -%}
+
+{%- if page.kernel_name %}
+    {% if page.kernel_name contains "python" %}
+        {% assign cm_language="python" %}
+    {% else %}
+        {% assign cm_language={{ page.kernel_name }} %}
+    {% endif %}
+{% else %}
+    {% assign cm_language="python" %}
+{% endif -%}
+{
+    requestKernel: true,
+    binderOptions: {
+    repo: "{{ site.binder_repo_org }}/{{ site.binder_repo_name }}",
+    ref: "{{ site.binder_repo_branch }}",
+    },
+    codeMirrorConfig: {
+    theme: "{{ site.codemirror_theme }}",
+    mode: "{{ cm_language }}"
+    },
+    kernelOptions: {
+    kernelName: "{{ kernelName }}",
+    path: "{{ page.kernel_path }}"
+    }
+}
+</script>

--- a/jupyter_book/book_template/_includes/js/thebelab.html
+++ b/jupyter_book/book_template/_includes/js/thebelab.html
@@ -3,39 +3,6 @@
 
 <!-- Display Thebelab button in each code cell -->
 {% include js/thebelab-cell-button.html %}
-
-<script type="text/x-thebe-config">
-    {% if page.kernel_name %}
-        {% assign kernelName = page.kernel_name %}
-    {% else %}
-        {% assign kernelName = "python3" %}
-    {% endif %}
-
-    {% if page.kernel_name %}
-        {% if page.kernel_name contains "python" %}
-            {% assign cm_language="python" %}
-        {% else %}
-            {% assign cm_language={{ page.kernel_name }} %}
-        {% endif %}
-    {% else %}
-        {% assign cm_language="python" %}
-    {% endif %}
-    {
-      requestKernel: true,
-      binderOptions: {
-        repo: '{{ site.binder_repo_org }}/{{ site.binder_repo_name }}',
-        ref: '{{ site.binder_repo_branch }}',
-      },
-      codeMirrorConfig: {
-        theme: "{{ site.codemirror_theme }}",
-        mode: "{{ cm_language }}"
-      },
-      kernelOptions: {
-        kernelName: '{{ kernelName }}',
-        path: "{{ page.kernel_path }}"
-      }
-    }
-</script>
 <script src="https://unpkg.com/thebelab@latest/lib/index.js" async></script>
 <script>
     /**
@@ -124,6 +91,5 @@ var detectLanguage = (language) => {
     }
     return language;
 }
-
 </script>
 {% endif %}

--- a/jupyter_book/book_template/_layouts/default.html
+++ b/jupyter_book/book_template/_layouts/default.html
@@ -2,6 +2,9 @@
 <html lang="en">
   {% include head.html %}
   <body>
+    <!-- Include the ThebeLab config so it gets reloaded on each page -->
+    {% include js/thebelab-page-config.html %}
+
     <!-- .js-show-sidebar shows sidebar by default -->
     <div id="js-textbook" class="c-textbook {% if site.show_sidebar %}js-show-sidebar{% endif %}">
       {% include sidebar.html %}


### PR DESCRIPTION
This moves the thebelab configuration inside `<body>` instead of `<head>` so that it is re-loaded when pages are visited with turbolinks. This should make the thebelab config properly update itself:

closes https://github.com/jupyter/jupyter-book/issues/96

