### PR TITLE
improving the upgrade functionality

### DIFF
--- a/jupyter_book/book_template/_config.yml
+++ b/jupyter_book/book_template/_config.yml
@@ -19,71 +19,72 @@
 title: Jupyter Book
 author: The Jupyter Book Community
 email: choldgraf@berkeley.edu
-description: >- # this means to ignore newlines until "baseurl:"
+description: >-
   This is an example book built with Jupyter Books.
 
-baseurl: "" # the subpath of your site, e.g. /blog. If there is no subpath for your site, use an empty string ""
-url: "https://jupyterbook.org" # the base hostname & protocol for your site, e.g. http://example.com
+baseurl: '' # the subpath of your site, e.g. /blog. If there is no subpath for your site, use an empty string ""
+url: https://jupyterbook.org   # the base hostname & protocol for your site, e.g. http://example.com
 
 
 #######################################################################################
 # Jupyter Book settings
 
 # Main page settings
-footer_text               : This page was created by <a href="https://github.com/jupyter/jupyter-book/graphs/contributors">The Jupyter Book Community</a>
+footer_text: This page was created by <a href="https://github.com/jupyter/jupyter-book/graphs/contributors">The
+  Jupyter Book Community</a>
 
 # Sidebar settings
-show_sidebar              : true  # Show the sidebar. Only set to false if your only wish to host a single page.
+show_sidebar: true                # Show the sidebar. Only set to false if your only wish to host a single page.
 collapse_inactive_chapters: true  # Whether to collapse the inactive chapters in the sidebar
 collapse_inactive_sections: true  # Whether to collapse the sub-sections within a non-active section in the sidebar
-textbook_logo             : images/logo/logo.png  # A logo to be displayed at the top of your textbook sidebar. Should be square
-textbook_logo_link        : https://jupyterbook.org/intro.html  # A link for the logo.
-sidebar_footer_text       : 'Powered by <a href="https://jupyterbook.org">Jupyter Book</a>'
-number_toc_chapters       : true  # Whether to add numbers to chapterse in your Table of Contents. If true, you can control this at the Chapter level in _data/toc.yml
+textbook_logo: images/logo/logo.png               # A logo to be displayed at the top of your textbook sidebar. Should be square
+textbook_logo_link: https://jupyterbook.org/intro.html          # A link for the logo.
+sidebar_footer_text: Powered by <a href="https://jupyterbook.org">Jupyter Book</a>
+number_toc_chapters: true         # Whether to add numbers to chapterse in your Table of Contents. If true, you can control this at the Chapter level in _data/toc.yml
 
 # Search settings
-search_max_words_in_content : 100  # In the search function, use at most this many words (too many words will make search slow)
+search_max_words_in_content: 100   # In the search function, use at most this many words (too many words will make search slow)
 
 # Controlling page information
-page_titles                    : infer  # Either `None`, `infer`, or `toc`
-page_authors                   : None  # Either `None` or `infer`
-filename_title_split_character : '_'  # If inferring titles based on filename, splt on this character.
+page_titles: infer                      # Either `None`, `infer`, or `toc`
+page_authors: None                     # Either `None` or `infer`
+filename_title_split_character: _     # If inferring titles based on filename, splt on this character.
 
 # Math settings
-number_equations               : false  # Whether to automatically number all block equations with MathJax
+number_equations: false                 # Whether to automatically number all block equations with MathJax
 
 #######################################################################################
 # Interact link settings
 
 # General interact settings
-use_jupyterlab                   : false  # If 'true', interact links will use JupyterLab as the interface
+use_jupyterlab: false                     # If 'true', interact links will use JupyterLab as the interface
 
 # Jupyterhub link settings
-use_jupyterhub_button            : false  # If 'true', display a button that will direct users to a JupyterHub (that you provide)
-jupyterhub_url                   : ""  # The URL for your JupyterHub. If no URL, use ""
-jupyterhub_interact_text         : "Interact"  # The text that interact buttons will contain.
+use_jupyterhub_button: false              # If 'true', display a button that will direct users to a JupyterHub (that you provide)
+jupyterhub_url: ''                     # The URL for your JupyterHub. If no URL, use ""
+jupyterhub_interact_text: Interact             # The text that interact buttons will contain.
 
 # Binder link settings
-use_binder_button                : true  # If 'true', add a binder button for interactive links
-binderhub_url                    : "https://mybinder.org"  # The URL for your BinderHub. If no URL, use ""
-binder_repo_base                 : "https://github.com/"  # The site on which the textbook repository is hosted
-binder_repo_org                  : "jupyter"  # The username or organization that owns this repository
-binder_repo_name                 : "jupyter-book"  # The name of the repository on the web
-binder_repo_branch               : "gh-pages"  # The branch on which your textbook is hosted.
-binderhub_interact_text          : "Interact"  # The text that interact buttons will contain.
+use_binder_button: true                  # If 'true', add a binder button for interactive links
+binderhub_url: https://mybinder.org                        # The URL for your BinderHub. If no URL, use ""
+binder_repo_base: https://github.com/                     # The site on which the textbook repository is hosted
+binder_repo_org: jupyter                      # The username or organization that owns this repository
+binder_repo_name: jupyter-book                     # The name of the repository on the web
+binder_repo_branch: gh-pages                   # The branch on which your textbook is hosted.
+binderhub_interact_text: Interact              # The text that interact buttons will contain.
 
 # Thebelab settings
-use_thebelab_button              : true  # If 'true', display a button to allow in-page running code cells with Thebelab
-thebelab_button_text             : "Thebelab"  # The text to display inside the Thebelab initialization button
-codemirror_theme                 : "abcdef"  # Theme for codemirror cells, for options see https://codemirror.net/doc/manual.html#config
+use_thebelab_button: true                # If 'true', display a button to allow in-page running code cells with Thebelab
+thebelab_button_text: Thebelab                 # The text to display inside the Thebelab initialization button
+codemirror_theme: abcdef                     # Theme for codemirror cells, for options see https://codemirror.net/doc/manual.html#config
 
 # nbinteract settings
-use_show_widgets_button              : true  # If 'true', display a button to allow in-page running code cells with nbinteract
+use_show_widgets_button: true                # If 'true', display a button to allow in-page running code cells with nbinteract
 
 # Download settings
-use_download_button              : true  # If 'true', display a button to download a zip file for the notebook
-download_button_text             : "Download" # The text that download buttons will contain
-download_page_header             : "Made with Jupyter Book" # A header that will be displayed at the top of and PDF-printed page
+use_download_button: true                # If 'true', display a button to download a zip file for the notebook
+download_button_text: Download                # The text that download buttons will contain
+download_page_header: Made with Jupyter Book                # A header that will be displayed at the top of and PDF-printed page
 
 #######################################################################################
 # Jupyter book extensions and additional features
@@ -102,11 +103,11 @@ google_analytics:
 #######################################################################################
 # Jupyter book settings you probably don't need to change
 
-content_folder_name       : "content"  # The folder where your raw content (notebooks/markdown files) are located
-images_url                : "/assets/images" # Path to static image files
-css_url                   : "/assets/css" # Path to static CSS files
-js_url                    : "/assets/js" # Path to JS files
-custom_static_url         : "/assets/custom" # Path to user's custom CSS/JS files
+content_folder_name: content           # The folder where your raw content (notebooks/markdown files) are located
+images_url: /assets/images                   # Path to static image files
+css_url: /assets/css                      # Path to static CSS files
+js_url: /assets/js                       # Path to JS files
+custom_static_url: /assets/custom            # Path to user's custom CSS/JS files
 
 
 #######################################################################################
@@ -114,16 +115,16 @@ custom_static_url         : "/assets/custom" # Path to user's custom CSS/JS file
 
 # Site settings
 defaults:
-  - scope:
-      path: ""
-    values:
-      layout: "default"
-      toc: true
-      toc_label: "  On this page"
-      toc_icon: "list-ul"
-      excerpt: ''
+- scope:
+    path: ''
+  values:
+    layout: default
+    toc: true
+    toc_label: '  On this page'
+    toc_icon: list-ul
+    excerpt: ''
 
-favicon_path: "images/logo/favicon.ico"
+favicon_path: images/logo/favicon.ico
 
 # Markdown Processing
 markdown: kramdown
@@ -143,18 +144,18 @@ collections:
 # The following items will not be processed, by default. Create a custom list
 # to override the default setting.
 exclude:
-  - scripts/
-  - Gemfile
-  - Gemfile.lock
-  - node_modules
-  - vendor/bundle/
-  - vendor/cache/
-  - vendor/gems/
-  - vendor/ruby/
+- scripts/
+- Gemfile
+- Gemfile.lock
+- node_modules
+- vendor/bundle/
+- vendor/cache/
+- vendor/gems/
+- vendor/ruby/
 
 plugins:
-  - jekyll-redirect-from
-  - jekyll-scholar
+- jekyll-redirect-from
+- jekyll-scholar
 
 # Jupyter Book version - DO NOT CHANGE THIS. It is generated when a new book is created
-jupyter_book_version: "0.6.4dev0"
+jupyter_book_version: 0.6.4dev0

--- a/jupyter_book/book_template/_config.yml
+++ b/jupyter_book/book_template/_config.yml
@@ -19,72 +19,71 @@
 title: Jupyter Book
 author: The Jupyter Book Community
 email: choldgraf@berkeley.edu
-description: >-
+description: >- # this means to ignore newlines until "baseurl:"
   This is an example book built with Jupyter Books.
 
-baseurl: '' # the subpath of your site, e.g. /blog. If there is no subpath for your site, use an empty string ""
-url: https://jupyterbook.org   # the base hostname & protocol for your site, e.g. http://example.com
+baseurl: "" # the subpath of your site, e.g. /blog. If there is no subpath for your site, use an empty string ""
+url: "https://jupyterbook.org" # the base hostname & protocol for your site, e.g. http://example.com
 
 
 #######################################################################################
 # Jupyter Book settings
 
 # Main page settings
-footer_text: This page was created by <a href="https://github.com/jupyter/jupyter-book/graphs/contributors">The
-  Jupyter Book Community</a>
+footer_text               : This page was created by <a href="https://github.com/jupyter/jupyter-book/graphs/contributors">The Jupyter Book Community</a>
 
 # Sidebar settings
-show_sidebar: true                # Show the sidebar. Only set to false if your only wish to host a single page.
+show_sidebar              : true  # Show the sidebar. Only set to false if your only wish to host a single page.
 collapse_inactive_chapters: true  # Whether to collapse the inactive chapters in the sidebar
 collapse_inactive_sections: true  # Whether to collapse the sub-sections within a non-active section in the sidebar
-textbook_logo: images/logo/logo.png               # A logo to be displayed at the top of your textbook sidebar. Should be square
-textbook_logo_link: https://jupyterbook.org/intro.html          # A link for the logo.
-sidebar_footer_text: Powered by <a href="https://jupyterbook.org">Jupyter Book</a>
-number_toc_chapters: true         # Whether to add numbers to chapterse in your Table of Contents. If true, you can control this at the Chapter level in _data/toc.yml
+textbook_logo             : images/logo/logo.png  # A logo to be displayed at the top of your textbook sidebar. Should be square
+textbook_logo_link        : https://jupyterbook.org/intro.html  # A link for the logo.
+sidebar_footer_text       : 'Powered by <a href="https://jupyterbook.org">Jupyter Book</a>'
+number_toc_chapters       : true  # Whether to add numbers to chapterse in your Table of Contents. If true, you can control this at the Chapter level in _data/toc.yml
 
 # Search settings
-search_max_words_in_content: 100   # In the search function, use at most this many words (too many words will make search slow)
+search_max_words_in_content : 100  # In the search function, use at most this many words (too many words will make search slow)
 
 # Controlling page information
-page_titles: infer                      # Either `None`, `infer`, or `toc`
-page_authors: None                     # Either `None` or `infer`
-filename_title_split_character: _     # If inferring titles based on filename, splt on this character.
+page_titles                    : infer  # Either `None`, `infer`, or `toc`
+page_authors                   : None  # Either `None` or `infer`
+filename_title_split_character : '_'  # If inferring titles based on filename, splt on this character.
 
 # Math settings
-number_equations: false                 # Whether to automatically number all block equations with MathJax
+number_equations               : false  # Whether to automatically number all block equations with MathJax
 
 #######################################################################################
 # Interact link settings
 
 # General interact settings
-use_jupyterlab: false                     # If 'true', interact links will use JupyterLab as the interface
+use_jupyterlab                   : false  # If 'true', interact links will use JupyterLab as the interface
 
 # Jupyterhub link settings
-use_jupyterhub_button: false              # If 'true', display a button that will direct users to a JupyterHub (that you provide)
-jupyterhub_url: ''                     # The URL for your JupyterHub. If no URL, use ""
-jupyterhub_interact_text: Interact             # The text that interact buttons will contain.
+use_jupyterhub_button            : false  # If 'true', display a button that will direct users to a JupyterHub (that you provide)
+jupyterhub_url                   : ""  # The URL for your JupyterHub. If no URL, use ""
+jupyterhub_interact_text         : "Interact"  # The text that interact buttons will contain.
 
 # Binder link settings
-use_binder_button: true                  # If 'true', add a binder button for interactive links
-binderhub_url: https://mybinder.org                        # The URL for your BinderHub. If no URL, use ""
-binder_repo_base: https://github.com/                     # The site on which the textbook repository is hosted
-binder_repo_org: jupyter                      # The username or organization that owns this repository
-binder_repo_name: jupyter-book                     # The name of the repository on the web
-binder_repo_branch: gh-pages                   # The branch on which your textbook is hosted.
-binderhub_interact_text: Interact              # The text that interact buttons will contain.
+use_binder_button                : true  # If 'true', add a binder button for interactive links
+binderhub_url                    : "https://mybinder.org"  # The URL for your BinderHub. If no URL, use ""
+binder_repo_base                 : "https://github.com/"  # The site on which the textbook repository is hosted
+binder_repo_org                  : "jupyter"  # The username or organization that owns this repository
+binder_repo_name                 : "jupyter-book"  # The name of the repository on the web
+binder_repo_branch               : "gh-pages"  # The branch on which your textbook is hosted.
+binderhub_interact_text          : "Interact"  # The text that interact buttons will contain.
 
 # Thebelab settings
-use_thebelab_button: true                # If 'true', display a button to allow in-page running code cells with Thebelab
-thebelab_button_text: Thebelab                 # The text to display inside the Thebelab initialization button
-codemirror_theme: abcdef                     # Theme for codemirror cells, for options see https://codemirror.net/doc/manual.html#config
+use_thebelab_button              : true  # If 'true', display a button to allow in-page running code cells with Thebelab
+thebelab_button_text             : "Thebelab"  # The text to display inside the Thebelab initialization button
+codemirror_theme                 : "abcdef"  # Theme for codemirror cells, for options see https://codemirror.net/doc/manual.html#config
 
 # nbinteract settings
-use_show_widgets_button: true                # If 'true', display a button to allow in-page running code cells with nbinteract
+use_show_widgets_button              : true  # If 'true', display a button to allow in-page running code cells with nbinteract
 
 # Download settings
-use_download_button: true                # If 'true', display a button to download a zip file for the notebook
-download_button_text: Download                # The text that download buttons will contain
-download_page_header: Made with Jupyter Book                # A header that will be displayed at the top of and PDF-printed page
+use_download_button              : true  # If 'true', display a button to download a zip file for the notebook
+download_button_text             : "Download" # The text that download buttons will contain
+download_page_header             : "Made with Jupyter Book" # A header that will be displayed at the top of and PDF-printed page
 
 #######################################################################################
 # Jupyter book extensions and additional features
@@ -103,11 +102,11 @@ google_analytics:
 #######################################################################################
 # Jupyter book settings you probably don't need to change
 
-content_folder_name: content           # The folder where your raw content (notebooks/markdown files) are located
-images_url: /assets/images                   # Path to static image files
-css_url: /assets/css                      # Path to static CSS files
-js_url: /assets/js                       # Path to JS files
-custom_static_url: /assets/custom            # Path to user's custom CSS/JS files
+content_folder_name       : "content"  # The folder where your raw content (notebooks/markdown files) are located
+images_url                : "/assets/images" # Path to static image files
+css_url                   : "/assets/css" # Path to static CSS files
+js_url                    : "/assets/js" # Path to JS files
+custom_static_url         : "/assets/custom" # Path to user's custom CSS/JS files
 
 
 #######################################################################################
@@ -115,16 +114,16 @@ custom_static_url: /assets/custom            # Path to user's custom CSS/JS file
 
 # Site settings
 defaults:
-- scope:
-    path: ''
-  values:
-    layout: default
-    toc: true
-    toc_label: '  On this page'
-    toc_icon: list-ul
-    excerpt: ''
+  - scope:
+      path: ""
+    values:
+      layout: "default"
+      toc: true
+      toc_label: "  On this page"
+      toc_icon: "list-ul"
+      excerpt: ''
 
-favicon_path: images/logo/favicon.ico
+favicon_path: "images/logo/favicon.ico"
 
 # Markdown Processing
 markdown: kramdown
@@ -144,18 +143,18 @@ collections:
 # The following items will not be processed, by default. Create a custom list
 # to override the default setting.
 exclude:
-- scripts/
-- Gemfile
-- Gemfile.lock
-- node_modules
-- vendor/bundle/
-- vendor/cache/
-- vendor/gems/
-- vendor/ruby/
+  - scripts/
+  - Gemfile
+  - Gemfile.lock
+  - node_modules
+  - vendor/bundle/
+  - vendor/cache/
+  - vendor/gems/
+  - vendor/ruby/
 
 plugins:
-- jekyll-redirect-from
-- jekyll-scholar
+  - jekyll-redirect-from
+  - jekyll-scholar
 
 # Jupyter Book version - DO NOT CHANGE THIS. It is generated when a new book is created
-jupyter_book_version: 0.6.4dev0
+jupyter_book_version: "0.6.4dev0"

--- a/jupyter_book/book_template/content/guide/05_faq.md
+++ b/jupyter_book/book_template/content/guide/05_faq.md
@@ -17,13 +17,15 @@ jupyter-book upgrade path/to/mybook
 
 This will do the following:
 
-1. Generate a fresh Jupyter Book in `mybook_UPGRADED` using the content files in your
-   current book.
-2. If this succeeds, copy over the contents of `mybook_UPGRADED` into your current book folder.
-3. If this succeeds, delete the `mybook_UPGRADED` folder.
+1. Generate a fresh Jupyter Book in a temporary folder using the content files
+   and configuration in your current book. You can specify files to manually keep
+   with `--extra-files=<comma-separated-list-of-paths>`.
+2. If this succeeds, delete all of the non-hidden files in your book's folder.
+3. Copy over the newly-generated book to your book's folder.
 
 Note that only the content that you can manually specify via the `jupyter-book create` command
-will be retained in your upgraded book. For a list of these options, see the help menu for this command:
+will be retained in your upgraded book (except for files you specify with `--extra-files`).
+For a list of these options, see the help menu for this command:
 
 ```bash
 jupyter-book create -h
@@ -31,6 +33,19 @@ jupyter-book create -h
 
 You should check out the content in your upgraded book to make sure it looks correct, then
 commit the changes to your repository.
+
+If something goes wrong, you may have a folder with partially-incorrect files. To
+totally reset the folder's contents (and assuming you are using version control),
+remove all of the files/folders that are in your book's folder, and then reset the
+state of the folder with `git`, like so:
+
+```
+cd path/to/mybook
+rm -rf ./*
+git reset --hard HEAD
+```
+
+This should reset the state of the folder to the last commit in your git history.
 
 ## Does the book behave differently depending on the browser?
 

--- a/jupyter_book/commands/upgrade.py
+++ b/jupyter_book/commands/upgrade.py
@@ -12,6 +12,13 @@ def upgrade():
     parser.add_argument(
         "path_book", help="Path to the root of the book "
                           "repository you'd like to upgrade.")
+    parser.add_argument(
+        "--extra-files", help="A comma-separated string of paths to extra files to include "
+                              "in the upgrade. If these files would normally be over-written by a "
+                              "update to Jupyter Book, they will not. If these files are not part "
+                              "of the default Jupyter Book structure, they will be included in the "
+                              "updated book.")
     args = parser.parse_args(sys.argv[2:])
     path_book = args.path_book.rstrip('/')
-    upgrade_book(path_book)
+    extra_files = args.extra_files.split(',') if args.extra_files else None
+    upgrade_book(path_book, extra_files=extra_files)

--- a/jupyter_book/create.py
+++ b/jupyter_book/create.py
@@ -308,9 +308,9 @@ def upgrade_book(path_book, extra_files=None):
 
         # A few optional files that are not strictly required
         optional_files = {
-            "license": path_book.joinpath('content', 'LICENSE.md'),
-            "custom_css": path_book.joinpath('assets', 'custom', 'custom.css'),
-            "custom_js": path_book.joinpath('assets', 'custom', 'custom.js')
+            "license": path_book / 'content' / 'LICENSE.md',
+            "custom_css": path_book / 'assets' / 'custom' / 'custom.css',
+            "custom_js": path_book / 'assets' / 'custom' / 'custom.js'
         }
         for key, path in optional_files.items():
             if not path.exists():
@@ -327,11 +327,14 @@ def upgrade_book(path_book, extra_files=None):
                      config=path_book.joinpath('_config.yml'),
                      custom_css=optional_files['custom_css'],
                      custom_js=optional_files['custom_js'],
-                     extra_files=extra_files,
+                     extra_files=[str(ifile) for ifile in extra_files],
                      overwrite=True, verbose=False)
 
             # Delete the files in the current folder
+            skip_folders = [".git", ".gitignore"]
             for ipath in path_book.glob('*'):
+                if any(sfolder in str(ipath) for sfolder in skip_folders):
+                    continue
                 if ipath.is_dir():
                     sh.rmtree(ipath)
                 else:

--- a/jupyter_book/tests/configs/config_simple.yml
+++ b/jupyter_book/tests/configs/config_simple.yml
@@ -1,3 +1,6 @@
+title: THIS SHOULD BE THE TITLE
 use_show_widgets_button: true
 use_thebelab_button: true
 use_download_button: true
+google_analytics:
+  mytrackingcode: 'NOT_OVERWRITTEN'

--- a/jupyter_book/tests/test_create.py
+++ b/jupyter_book/tests/test_create.py
@@ -126,29 +126,36 @@ def test_config_update(tmpdir):
 
 
 def test_upgrade(tmpdir):
-    path_build_test = Path(tmpdir.dirpath()).joinpath('tmp_test', 'test')
+    path_build_test = Path(tmpdir.dirpath()) / 'tmp_test' / 'test'
 
     # Change the contents of a file in test to see if it is updated
-    path_build_test.joinpath('assets', 'css', 'styles.scss').write_text('RANDOMTEXT')
-    cmd = ["jupyter-book", 'upgrade', str(path_build_test)]
+    (path_build_test / 'assets' / 'css' / 'styles.scss').write_text('RANDOMTEXT')
+    cmd = ["jupyter-book", 'upgrade', str(path_build_test),
+           "--extra-files", path_build_test / 'baz.txt']
     run(cmd, check=True)
 
     # Make sure the test contents are the same
-    text = path_build_test.joinpath('assets', 'css', 'styles.scss').read_text()
+    text = (path_build_test / 'assets' / 'css' / 'styles.scss').read_text()
     assert "RANDOMTEXT" not in text
 
     # Make sure the requirements file was copied over properly
-    text = path_build_test.joinpath('requirements.txt').read_text()
+    text = (path_build_test / 'requirements.txt').read_text()
     assert "mytestrequirement" in text
 
     # Make sure the bibliography file was copied over properly
-    text = path_build_test.joinpath('_bibliography', 'references.bib').read_text()
+    text = (path_build_test / '_bibliography' / 'references.bib').read_text()
     assert "my_references" in text
 
     # Make sure that old configuration values are not overwritten
-    config = yaml.load(path_build_test.joinpath('_config.yml').read_text())
+    config = yaml.load((path_build_test / '_config.yml').read_text())
     assert config.get('google_analytics').get('mytrackingcode') == 'NOT_OVERWRITTEN'
     assert config.get('title') == "THIS SHOULD BE THE TITLE"
+
+    # Make sure that specified extra files are kept, and non-specified extras are gone
+    path_extra = path_build_test / 'baz.txt'
+    path_skipped = path_build_test / 'you'
+    assert path_extra.exists()
+    assert not path_skipped.exists()
 
 ########################################################################################################
 # Building the book after the book is created


### PR DESCRIPTION
This should make the upgrade functionality a little bit cleaner. Instead of copy/pasting all of the new files into the folder and storing the folder in `./mybook_NEW`, it instead uses a temporary folder and cleans out the old book folder first.

closes #434 
partially addresses https://github.com/jupyter/jupyter-book/issues/428