### PR TITLE
Add installation module and fix circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,4 +140,8 @@ commands:
       # Build the book's HTML w/ the base_url for CircleCI artifacts
       - run:
           name: Install book Ruby dependencies
-          command: cd jupyter_book/book_template && rm Gemfile.lock && bundle install
+          command: |
+            cd jupyter_book/book_template
+            sudo apt install libffi-dev
+            rm Gemfile.lock
+            make install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,11 @@ commands:
       - run:
           name: Install book Ruby dependencies
           command: |
+            export MINICONDA=$HOME/miniconda
+            echo "export PATH=$MINICONDA/bin:$PATH" >> $BASH_ENV
+            source $BASH_ENV
+            pip install --user -e ./
+            conda install gxx_linux-64
             cd jupyter_book/book_template
-            sudo apt install libffi-dev
             rm Gemfile.lock
             make install

--- a/jupyter_book/book_template/Makefile
+++ b/jupyter_book/book_template/Makefile
@@ -12,11 +12,7 @@ help:
 
 
 install:
-	# Check to see whether bundler is already installed. If not, install it.
-	if [ hash bundler 2>/dev/null ]; then \
-	gem install bundler;\
-	fi
-	bundle install
+	jupyter-book install ./
 
 book:
 	jupyter-book build ./

--- a/jupyter_book/commands/__init__.py
+++ b/jupyter_book/commands/__init__.py
@@ -6,3 +6,4 @@ from .run import run
 from .version import version
 from .toc import toc
 from .page import page
+from .install import install

--- a/jupyter_book/commands/install.py
+++ b/jupyter_book/commands/install.py
@@ -1,0 +1,40 @@
+import sys
+import argparse
+from pathlib import Path
+from subprocess import run
+from ..utils import print_message_box
+
+
+def install():
+    parser = argparse.ArgumentParser(
+        description="Install the necessary dependencies to build a Jupyter Book."
+    )
+    parser.add_argument(
+        "path_book",
+        help="Path to the root of the book "
+        "repository for which you're installing depdendencies.",
+    )
+
+    args = parser.parse_args(sys.argv[2:])
+    path_book = Path(args.path_book)
+
+    def myrun(cmd, verbose=True):
+        if verbose:
+            print("Running: " + cmd)
+        run(cmd.split(), cwd=path_book, check=True)
+
+    # Check to see whether bundler is already installed. If not, install it.
+    try:
+        myrun("bundler -v", False)
+    except Exception:
+        myrun("gem install bundler")
+
+    # Now install with bundle
+    try:
+        myrun("bundle install")
+    except Exception:
+        # Try installing nokogiri first because it's a PITA on some machines
+        myrun("bundle config --global build.nokogiri --use-system-libraries")
+        myrun("bundle install")
+
+    print_message_box("Finished installing dependencies...")

--- a/jupyter_book/main.py
+++ b/jupyter_book/main.py
@@ -1,7 +1,7 @@
 import sys
 import argparse
 
-from .commands import build, create, upgrade, version, page, toc, run
+from .commands import build, create, upgrade, version, page, toc, run, install
 
 DESCRIPTION = (
     "Jupyter Book: Generate an HTML book from your Jupyter Notebooks using"
@@ -12,7 +12,8 @@ commands = {'create': create,
             'upgrade': upgrade,
             'run': run,
             'toc': toc,
-            'version': version}
+            'version': version,
+            'install': install}
 parser = argparse.ArgumentParser(description=DESCRIPTION)
 parser.add_argument("command", help="The command you'd like to run. Allowed commands: {}".format(
     list(commands.keys())))


### PR DESCRIPTION
This adds an `install` module and CLI option, which uses Python logic to handle the installation step (currently being done with `make install`). This should let us extend this functionality if need be, and also follows the same pattern our other commands are.