### PR TITLE
Display the Jupyter Book icon on pypi

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <img src="jupyter_book/book_template/content/images/logo/logo.png" width=40 /> Jupyter Book
+# <img src="https://raw.githubusercontent.com/jupyter/jupyter-book/master/jupyter_book/book_template/content/images/logo/logo.png" width=40 /> Jupyter Book
 
 [![CircleCI](https://circleci.com/gh/jupyter/jupyter-book.svg?style=svg)](https://circleci.com/gh/jupyter/jupyter-book)
 [![codecov](https://codecov.io/gh/jupyter/jupyter-book/branch/master/graph/badge.svg)](https://codecov.io/gh/jupyter/jupyter-book)


### PR DESCRIPTION
Currently the Jupyter Book icon does not appear at https://pypi.org/project/jupyter-book/ . In my experience, using the full _raw content URL_ does fix this kind of issues.
