### PR TITLE
[ENH] Raise error if page URL does not start with os.sep

### DIFF
--- a/jupyter_book/utils.py
+++ b/jupyter_book/utils.py
@@ -79,6 +79,10 @@ def _check_url_page(url_page, content_folder_name):
                 url_page
             )
         )
+    if not url_page.startswith(os.sep):
+        raise ValueError(
+            "Page URLs need to start with {}. Here is the page URL: {}".format(os.sep, url_page)
+            )
 
 
 def _prepare_url(url):

--- a/jupyter_book/utils.py
+++ b/jupyter_book/utils.py
@@ -82,7 +82,7 @@ def _check_url_page(url_page, content_folder_name):
     if not url_page.startswith(os.sep):
         raise ValueError(
             "Page URLs need to start with {}. Here is the page URL: {}".format(os.sep, url_page)
-            )
+        )
 
 
 def _prepare_url(url):


### PR DESCRIPTION
This addresses #466 

Refuse to build and raise a helpful error if we encounter a page URL that doesn't begin with `os.sep` (usually `/`)